### PR TITLE
Accessibility fixes across site + Lighthouse cleanup + automated a11y tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "scripts": {
     "dev": "next",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "test:a11y": "playwright test -c playwright.a11y.config.ts"
   },
   "dependencies": {
     "@chakra-ui/react": "^3.2.4",
@@ -29,9 +30,12 @@
     "remark-toc": "^9.0.0"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.11.1",
+    "@playwright/test": "^1.58.2",
     "@types/node": "^22.10.2",
     "@types/react": "19.2.14",
     "@types/react-dom": "19.2.3",
+    "axe-core": "^4.11.1",
     "eslint": "9.17.0",
     "eslint-config-next": "16.1.6",
     "prettier": "^3.0.3",

--- a/playwright.a11y.config.ts
+++ b/playwright.a11y.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests/a11y",
+  timeout: 45_000,
+  expect: {
+    timeout: 10_000,
+  },
+  fullyParallel: true,
+  retries: 0,
+  reporter: [["list"]],
+  use: {
+    baseURL: "http://127.0.0.1:3000",
+    trace: "on-first-retry",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: {
+    command: "yarn dev -p 3000",
+    url: "http://127.0.0.1:3000",
+    reuseExistingServer: true,
+    timeout: 120_000,
+  },
+});

--- a/src/app/(home)/blogs/[id]/Client.tsx
+++ b/src/app/(home)/blogs/[id]/Client.tsx
@@ -42,15 +42,15 @@ function DateRow({
   const updatedLabel = formatDate(updated);
   if (!publishedLabel) return null;
   return (
-    <HStack gap={3} px={[4, 6]} fontSize="sm" color="gray.500">
+    <HStack gap={3} px={[4, 6]} fontSize="sm" color="app.fg.muted">
       <Text>
-        <Text as="span" color="gray.500">
+        <Text as="span" color="app.fg.muted">
           {publishedLabel}
         </Text>
         {updatedLabel ? (
           <Text
             as="span"
-            color="gray.500"
+            color="app.fg.muted"
           >{` (updated on ${updatedLabel})`}</Text>
         ) : null}
       </Text>

--- a/src/app/(home)/blogs/[id]/Client.tsx
+++ b/src/app/(home)/blogs/[id]/Client.tsx
@@ -31,6 +31,12 @@ function formatDate(value?: string) {
   });
 }
 
+function parseDate(value?: string) {
+  if (!value) return null;
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
 function DateRow({
   published,
   updated,
@@ -38,18 +44,25 @@ function DateRow({
   published?: string;
   updated?: string;
 }) {
-  const publishedLabel = formatDate(published);
-  const updatedLabel = formatDate(updated);
-  if (!publishedLabel) return null;
+  const publishedDate = parseDate(published);
+  const updatedDate = parseDate(updated);
+  if (!publishedDate) return null;
+
+  const publishedLabel = formatDate(publishedDate.toISOString());
+  const updatedLabel = updatedDate
+    ? formatDate(updatedDate.toISOString())
+    : null;
+
   return (
     <HStack gap={3} px={[4, 6]} fontSize="sm" color="app.fg.muted">
-      <Text>
-        <Text as="span" color="app.fg.muted">
+      <Text as="p">
+        <Text as="time" dateTime={publishedDate.toISOString()} color="app.fg.muted">
           {publishedLabel}
         </Text>
-        {updatedLabel ? (
+        {updatedDate && updatedLabel ? (
           <Text
-            as="span"
+            as="time"
+            dateTime={updatedDate.toISOString()}
             color="app.fg.muted"
           >{` (updated on ${updatedLabel})`}</Text>
         ) : null}
@@ -88,7 +101,7 @@ export default function Client({ html, blog }: { html: string; blog: Blog }) {
   if (!blog) return null;
 
   return (
-    <VStack align={"stretch"} gap={4}>
+    <VStack as="article" align={"stretch"} gap={4}>
       <DetailTitleBar title={blog.title} />
       <DateRow published={blog.published} updated={blog.updated} />
       <TagRow tags={blog.tags} />

--- a/src/app/(home)/page.tsx
+++ b/src/app/(home)/page.tsx
@@ -1,6 +1,17 @@
 "use client";
 
-import { EmptyState, VStack, HStack, Box, Icon } from "@chakra-ui/react";
+import {
+  EmptyState,
+  VStack,
+  HStack,
+  Box,
+  Icon,
+  Link,
+  QrCode,
+  Text,
+  Wrap,
+  WrapItem,
+} from "@chakra-ui/react";
 import { SectionText } from "@components/core/Texts";
 import {
   TileList,
@@ -15,10 +26,12 @@ import Profile from "@components/page/home/Profile";
 import ProjectsData from "data/projects";
 import { homepageTabs } from "app/route-info";
 import { WorkData } from "data";
+import PersonalData from "data/Personal";
 import TimeBasedOnlineStatusBadge from "@components/page/home/TimeBasedOnlineStatusBadge";
 import { useFeatureFlag } from "utils/features";
 import FeatureFlagsData from "data/features";
 import { FiBriefcase, FiTool, FiChevronRight } from "react-icons/fi";
+import { getAllTools } from "features/tools/data/tools-registry";
 
 function Main() {
   return (
@@ -150,12 +163,99 @@ function ExtraInfo() {
   return <BottomMessage />;
 }
 
+function getYearsOfExperience() {
+  const earliestStart = WorkData.experience.reduce((start, exp) => {
+    return exp.time.start < start ? exp.time.start : start;
+  }, WorkData.experience[0]?.time.start ?? new Date());
+
+  const years =
+    (Date.now() - earliestStart.getTime()) / (1000 * 60 * 60 * 24 * 365.25);
+  return Math.max(1, Math.floor(years));
+}
+
+function StatsAndQr() {
+  const stats = [
+    {
+      label: "Projects",
+      value: ProjectsData.allProjects.length,
+    },
+    {
+      label: "Experience",
+      value: `${getYearsOfExperience()}+ yrs`,
+    },
+    {
+      label: "Tools",
+      value: getAllTools().length,
+    },
+  ];
+
+  return (
+    <HighlightedSection title="Stats & QR" separateHeader>
+      <VStack align={"stretch"} gap={6}>
+        <Wrap gap={3}>
+          {stats.map((stat) => (
+            <WrapItem key={stat.label} flex={1} minW={"120px"}>
+              <Box
+                w={"full"}
+                borderWidth={"thin"}
+                borderColor={"app.border.default"}
+                borderRadius={"xl"}
+                px={4}
+                py={3}
+                background={"app.bg.cardHeader"}
+              >
+                <Text fontSize={"2xl"} fontWeight={"semibold"}>
+                  {stat.value}
+                </Text>
+                <Text color={"app.fg.subtle"}>{stat.label}</Text>
+              </Box>
+            </WrapItem>
+          ))}
+        </Wrap>
+
+        <VStack align={"center"} gap={3}>
+          <Text color={"app.fg.subtle"} textAlign={"center"}>
+            Scan to open LinkedIn profile
+          </Text>
+          <Box
+            borderWidth={"thin"}
+            borderColor={"app.border.default"}
+            borderRadius={"xl"}
+            p={3}
+            background={"white"}
+          >
+            <QrCode.Root
+              value={PersonalData.linkedIn.url}
+              aria-label={"QR code for LinkedIn profile"}
+            >
+              <QrCode.Frame boxSize={"120px"}>
+                <QrCode.Pattern />
+              </QrCode.Frame>
+            </QrCode.Root>
+          </Box>
+          <Link
+            href={PersonalData.linkedIn.url}
+            target={"_blank"}
+            rel={"noreferrer"}
+            color={"app.fg.subtle"}
+            textDecoration={"underline"}
+            textUnderlineOffset={"3px"}
+          >
+            {PersonalData.linkedIn.url}
+          </Link>
+        </VStack>
+      </VStack>
+    </HighlightedSection>
+  );
+}
+
 export default function Home() {
   return (
     <VStack align={"stretch"}>
       <Main />
       <WorkExperience />
       <Projects />
+      <StatsAndQr />
       <ExtraInfo />
     </VStack>
   );

--- a/src/app/(home)/page.tsx
+++ b/src/app/(home)/page.tsx
@@ -6,11 +6,6 @@ import {
   HStack,
   Box,
   Icon,
-  Link,
-  QrCode,
-  Text,
-  Wrap,
-  WrapItem,
 } from "@chakra-ui/react";
 import { SectionText } from "@components/core/Texts";
 import {
@@ -26,12 +21,10 @@ import Profile from "@components/page/home/Profile";
 import ProjectsData from "data/projects";
 import { homepageTabs } from "app/route-info";
 import { WorkData } from "data";
-import PersonalData from "data/Personal";
 import TimeBasedOnlineStatusBadge from "@components/page/home/TimeBasedOnlineStatusBadge";
 import { useFeatureFlag } from "utils/features";
 import FeatureFlagsData from "data/features";
 import { FiBriefcase, FiTool, FiChevronRight } from "react-icons/fi";
-import { getAllTools } from "features/tools/data/tools-registry";
 
 function Main() {
   return (
@@ -163,99 +156,12 @@ function ExtraInfo() {
   return <BottomMessage />;
 }
 
-function getYearsOfExperience() {
-  const earliestStart = WorkData.experience.reduce((start, exp) => {
-    return exp.time.start < start ? exp.time.start : start;
-  }, WorkData.experience[0]?.time.start ?? new Date());
-
-  const years =
-    (Date.now() - earliestStart.getTime()) / (1000 * 60 * 60 * 24 * 365.25);
-  return Math.max(1, Math.floor(years));
-}
-
-function StatsAndQr() {
-  const stats = [
-    {
-      label: "Projects",
-      value: ProjectsData.allProjects.length,
-    },
-    {
-      label: "Experience",
-      value: `${getYearsOfExperience()}+ yrs`,
-    },
-    {
-      label: "Tools",
-      value: getAllTools().length,
-    },
-  ];
-
-  return (
-    <HighlightedSection title="Stats & QR" separateHeader>
-      <VStack align={"stretch"} gap={6}>
-        <Wrap gap={3}>
-          {stats.map((stat) => (
-            <WrapItem key={stat.label} flex={1} minW={"120px"}>
-              <Box
-                w={"full"}
-                borderWidth={"thin"}
-                borderColor={"app.border.default"}
-                borderRadius={"xl"}
-                px={4}
-                py={3}
-                background={"app.bg.cardHeader"}
-              >
-                <Text fontSize={"2xl"} fontWeight={"semibold"}>
-                  {stat.value}
-                </Text>
-                <Text color={"app.fg.subtle"}>{stat.label}</Text>
-              </Box>
-            </WrapItem>
-          ))}
-        </Wrap>
-
-        <VStack align={"center"} gap={3}>
-          <Text color={"app.fg.subtle"} textAlign={"center"}>
-            Scan to open LinkedIn profile
-          </Text>
-          <Box
-            borderWidth={"thin"}
-            borderColor={"app.border.default"}
-            borderRadius={"xl"}
-            p={3}
-            background={"white"}
-          >
-            <QrCode.Root
-              value={PersonalData.linkedIn.url}
-              aria-label={"QR code for LinkedIn profile"}
-            >
-              <QrCode.Frame boxSize={"120px"}>
-                <QrCode.Pattern />
-              </QrCode.Frame>
-            </QrCode.Root>
-          </Box>
-          <Link
-            href={PersonalData.linkedIn.url}
-            target={"_blank"}
-            rel={"noreferrer"}
-            color={"app.fg.subtle"}
-            textDecoration={"underline"}
-            textUnderlineOffset={"3px"}
-          >
-            {PersonalData.linkedIn.url}
-          </Link>
-        </VStack>
-      </VStack>
-    </HighlightedSection>
-  );
-}
-
 export default function Home() {
   return (
     <VStack align={"stretch"}>
       <Main />
       <WorkExperience />
       <Projects />
-      <StatsAndQr />
       <ExtraInfo />
     </VStack>
   );

--- a/src/app/(home)/projects/[id]/Client.tsx
+++ b/src/app/(home)/projects/[id]/Client.tsx
@@ -43,7 +43,7 @@ export default function Client({
   if (!project) return null;
 
   return (
-    <VStack align={"stretch"} gap={4}>
+    <VStack as="article" align={"stretch"} gap={4}>
       <DetailTitleBar title={project.title} />
       <MetaRow
         description={project.description}

--- a/src/app/globalStyles.ts
+++ b/src/app/globalStyles.ts
@@ -72,6 +72,11 @@ export function getAppGlobalStyles(proseStyles: unknown): GlobalStyles {
       transform: "translateY(0%)",
       outline: "none",
     },
+    "a:focus-visible, button:focus-visible, [role='button']:focus-visible, input:focus-visible, textarea:focus-visible, select:focus-visible":
+      {
+        outline: "2px solid var(--chakra-colors-blue-500)",
+        outlineOffset: "2px",
+      },
     ".prose-content": proseStyles,
     ...HANDWRITTEN_BASE_STYLES,
     ...HANDWRITTEN_SQUIGGLE_STYLES,

--- a/src/app/globalStyles.ts
+++ b/src/app/globalStyles.ts
@@ -54,6 +54,24 @@ const HANDWRITTEN_SQUIGGLE_STYLES: GlobalStyles = {
 
 export function getAppGlobalStyles(proseStyles: unknown): GlobalStyles {
   return {
+    ".skip-link": {
+      position: "fixed",
+      top: "12px",
+      left: "12px",
+      transform: "translateY(-140%)",
+      background: "var(--chakra-colors-app-bg-card)",
+      color: "var(--chakra-colors-app-fg-default)",
+      border: "2px solid var(--chakra-colors-app-border-default)",
+      borderRadius: "10px",
+      padding: "8px 12px",
+      zIndex: 999,
+      textDecoration: "none",
+      transition: "transform 0.16s ease",
+    },
+    ".skip-link:focus-visible": {
+      transform: "translateY(0%)",
+      outline: "none",
+    },
     ".prose-content": proseStyles,
     ...HANDWRITTEN_BASE_STYLES,
     ...HANDWRITTEN_SQUIGGLE_STYLES,

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -41,6 +41,9 @@ export default function RootLayout({
       <body
         className={`${notoSans.className} ${lexend.variable} ${notoSans.variable} ${handwritten.variable}`}
       >
+        <a className="skip-link" href="#main-content">
+          Skip to main content
+        </a>
         <Providers>{children}</Providers>
       </body>
     </html>

--- a/src/components/core/Cards.tsx
+++ b/src/components/core/Cards.tsx
@@ -5,9 +5,6 @@ export function HeaderCard({ children }) {
   return (
     <Box
       background={"app.bg.cardHeader"}
-      backgroundImage={
-        "radial-gradient(circle at 20% 25%, rgba(56, 189, 248, 0.12) 0 2px, transparent 2px), radial-gradient(circle at 80% 70%, rgba(244, 114, 182, 0.1) 0 1.5px, transparent 1.5px), radial-gradient(circle at 45% 80%, rgba(34, 197, 94, 0.1) 0 1px, transparent 1px)"
-      }
       shadow={"sm"}
       borderWidth={0}
       borderColor={"app.border.default"}
@@ -24,9 +21,6 @@ export function MainCard({ children }) {
   return (
     <Box
       background={"app.bg.card"}
-      backgroundImage={
-        "radial-gradient(circle at 12% 18%, rgba(56, 189, 248, 0.08) 0 1.5px, transparent 1.5px), radial-gradient(circle at 88% 74%, rgba(251, 113, 133, 0.08) 0 1.5px, transparent 1.5px), radial-gradient(circle at 52% 62%, rgba(16, 185, 129, 0.08) 0 1px, transparent 1px)"
-      }
       borderWidth={0}
       borderColor={"app.border.default"}
       borderRadius={"2xl"}

--- a/src/components/core/Cards.tsx
+++ b/src/components/core/Cards.tsx
@@ -5,6 +5,9 @@ export function HeaderCard({ children }) {
   return (
     <Box
       background={"app.bg.cardHeader"}
+      backgroundImage={
+        "radial-gradient(circle at 20% 25%, rgba(56, 189, 248, 0.12) 0 2px, transparent 2px), radial-gradient(circle at 80% 70%, rgba(244, 114, 182, 0.1) 0 1.5px, transparent 1.5px), radial-gradient(circle at 45% 80%, rgba(34, 197, 94, 0.1) 0 1px, transparent 1px)"
+      }
       shadow={"sm"}
       borderWidth={0}
       borderColor={"app.border.default"}
@@ -21,6 +24,9 @@ export function MainCard({ children }) {
   return (
     <Box
       background={"app.bg.card"}
+      backgroundImage={
+        "radial-gradient(circle at 12% 18%, rgba(56, 189, 248, 0.08) 0 1.5px, transparent 1.5px), radial-gradient(circle at 88% 74%, rgba(251, 113, 133, 0.08) 0 1.5px, transparent 1.5px), radial-gradient(circle at 52% 62%, rgba(16, 185, 129, 0.08) 0 1px, transparent 1px)"
+      }
       borderWidth={0}
       borderColor={"app.border.default"}
       borderRadius={"2xl"}

--- a/src/components/core/Images.tsx
+++ b/src/components/core/Images.tsx
@@ -21,7 +21,7 @@ export function ImageBlock({
         borderColor={"app.border.muted"}
         background={"app.bg.canvas"}
       >
-        <Image src={src} rounded={"xl"} alt={""} />
+        <Image src={src} rounded={"xl"} alt={alt ?? caption ?? ""} />
         {caption ? <Text>{caption}</Text> : null}
       </VStack>
     </Center>

--- a/src/components/core/Texts.tsx
+++ b/src/components/core/Texts.tsx
@@ -32,14 +32,14 @@ export function SectionText({
           <FaCircle />
         </Icon>
       )}
-      <Heading
-        as="h3"
+      <Text
+        as="p"
         color={useDefaultTextColor()}
         fontSize={"lg"}
         fontWeight={"normal"}
       >
         {children}
-      </Heading>
+      </Text>
     </HStack>
   );
 }

--- a/src/components/core/Texts.tsx
+++ b/src/components/core/Texts.tsx
@@ -86,7 +86,7 @@ export const Heading3 = GetCustomHeading({
 });
 
 export const Heading4 = GetCustomHeading({
-  as: "h4",
+  as: "h2",
   fontSize: "lg",
   fontWeight: "medium",
 });

--- a/src/components/core/Tiles.tsx
+++ b/src/components/core/Tiles.tsx
@@ -4,7 +4,6 @@ import {
   Icon,
   useBreakpointValue,
   Box,
-  Heading,
   Text,
   Wrap,
   WrapItem,
@@ -155,9 +154,9 @@ export function TitleDescriptionAvatarTile({
                 <Avatar size={"md"} name={title} src={avatarSrc} />
               </Box>
               <VStack align={"start"} gap={compact ? 1 : 1}>
-                <Heading as="h4" fontSize={"lg"} fontWeight="medium">
+                <Text fontSize={"lg"} fontWeight="medium" color={"app.fg.default"}>
                   {title}
-                </Heading>
+                </Text>
                 {showDescriptionBelow ? null : descriptionJsx}
               </VStack>
             </HStack>
@@ -223,9 +222,9 @@ export function TitleDescriptionTile({
         <VStack align={"stretch"}>
           <HStack justify={"space-between"} align={"start"}>
             <VStack align={"start"} gap={1}>
-              <Heading as="h4" fontSize={"lg"} fontWeight="medium">
+              <Text fontSize={"lg"} fontWeight="medium" color={"app.fg.default"}>
                 {title}
-              </Heading>
+              </Text>
               {descriptionJsx}
             </VStack>
             {url ? <LinkHelperIcon isExternal={isUrlExternal} /> : null}
@@ -265,9 +264,9 @@ export function TitleDescriptionMetaTile({
         <VStack align={"stretch"} gap={2}>
           <HStack justify={"space-between"} align={"start"}>
             <VStack align={"start"} gap={0}>
-              <Heading as="h4" fontSize={"lg"} fontWeight="medium">
+              <Text fontSize={"lg"} fontWeight="medium" color={"app.fg.default"}>
                 {title}
-              </Heading>
+              </Text>
               {descriptionJsx}
             </VStack>
             {url ? <LinkHelperIcon isExternal={isUrlExternal} /> : null}
@@ -333,9 +332,9 @@ export function TitleCategoryAvatarTile({
                 <Avatar size={"sm"} name={title} src={avatarSrc} />
               </Box>
               <VStack align={"start"}>
-                <Heading as="h4" fontSize={"lg"} fontWeight="medium">
+                <Text fontSize={"lg"} fontWeight="medium" color={"app.fg.default"}>
                   {title}
-                </Heading>
+                </Text>
               </VStack>
             </HStack>
             <HStack gap={4}>
@@ -404,14 +403,15 @@ export function TitleDescriptionToggleTile({
         <VStack align={"stretch"}>
           <HStack justify={"space-between"}>
             <VStack align={"start"}>
-              <Heading as="h4" fontSize={"lg"} fontWeight="medium">
+              <Text fontSize={"lg"} fontWeight="medium" color={"app.fg.default"}>
                 {title}
-              </Heading>
+              </Text>
               {descriptionJsx}
             </VStack>
             <Switch
               checked={toggleValue}
               onCheckedChange={(details) => onToggle?.(details.checked)}
+              inputProps={{ "aria-label": title }}
             />
           </HStack>
         </VStack>

--- a/src/components/core/Tiles.tsx
+++ b/src/components/core/Tiles.tsx
@@ -169,6 +169,12 @@ export function TitleDescriptionAvatarTile({
   );
 }
 
+function parseBlogDate(value?: string) {
+  if (!value) return null;
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
 function formatBlogDateLabel({
   published,
   updated,
@@ -176,10 +182,8 @@ function formatBlogDateLabel({
   published?: string;
   updated?: string;
 }) {
-  if (!published) return null;
-
-  const publishedDate = new Date(published);
-  if (Number.isNaN(publishedDate.getTime())) return null;
+  const publishedDate = parseBlogDate(published);
+  if (!publishedDate) return null;
 
   const publishedLabel = publishedDate.toLocaleDateString(undefined, {
     year: "numeric",
@@ -187,10 +191,14 @@ function formatBlogDateLabel({
     day: "numeric",
   });
 
-  if (!updated) return publishedLabel;
-
-  const updatedDate = new Date(updated);
-  if (Number.isNaN(updatedDate.getTime())) return publishedLabel;
+  const updatedDate = parseBlogDate(updated);
+  if (!updatedDate) {
+    return (
+      <Text as="time" dateTime={publishedDate.toISOString()} fontSize={"sm"}>
+        {publishedLabel}
+      </Text>
+    );
+  }
 
   const updatedLabel = updatedDate.toLocaleDateString(undefined, {
     year: "numeric",
@@ -198,7 +206,17 @@ function formatBlogDateLabel({
     day: "numeric",
   });
 
-  return `${publishedLabel} · Updated ${updatedLabel}`;
+  return (
+    <Text as="span" fontSize={"sm"}>
+      <Text as="time" dateTime={publishedDate.toISOString()}>
+        {publishedLabel}
+      </Text>
+      {" · Updated "}
+      <Text as="time" dateTime={updatedDate.toISOString()}>
+        {updatedLabel}
+      </Text>
+    </Text>
+  );
 }
 
 export function TitleDescriptionTile({
@@ -273,7 +291,7 @@ export function TitleDescriptionMetaTile({
           </HStack>
 
           {metadataLabel ? (
-            <Text fontSize={"sm"} color={metadataColor}>
+            <Text color={metadataColor}>
               {metadataLabel}
             </Text>
           ) : null}

--- a/src/components/core/Tiles.tsx
+++ b/src/components/core/Tiles.tsx
@@ -95,7 +95,7 @@ function LinkOverlayIfUrlPresent({
       <a
         href={url}
         target="_blank"
-        rel="noreferrer"
+        rel="noopener noreferrer"
         style={{ display: "block" }}
       >
         {children}

--- a/src/components/page/common/CopyEmailSecondaryButton.tsx
+++ b/src/components/page/common/CopyEmailSecondaryButton.tsx
@@ -25,6 +25,7 @@ export default function CopyEmailButton() {
               shadow="xs"
               rounded="xl"
               variant="subtle"
+              aria-label="Copy Email"
             >
               <Clipboard.Indicator copied={<Icon as={FiCheck} />}>
                 <Icon as={FiCopy} />

--- a/src/components/page/common/CopyLinkSecondaryButton.tsx
+++ b/src/components/page/common/CopyLinkSecondaryButton.tsx
@@ -19,44 +19,51 @@ export default function CopyLinkSecondaryButton({
   }, []);
 
   return (
-    <Tooltip content={"Copy link"} showArrow closeOnScroll>
-      <Clipboard.Root value={currentUrl} timeout={1000}>
-        <Clipboard.Trigger asChild>
-          <HStack
-            as="button"
-            type="button"
-            gap={iconOnly ? 0 : 2}
-            fontFamily="ui"
-            fontSize="sm"
-            color="app.fg.subtle"
-            cursor="pointer"
-            px={iconOnly ? 2 : 3}
-            py={iconOnly ? 2 : 1.5}
-            rounded="full"
-            borderWidth="1px"
-            borderColor="app.border.default"
-            bg="app.bg.default"
-            transition="all 0.16s ease"
-            minH={iconOnly ? 8 : 10}
-            minW={iconOnly ? 8 : 10}
-            _hover={{
-              color: "app.fg.default",
-              borderColor: "app.fg.icon",
-              bg: "app.bg.subtle",
-              transform: "translateY(-1px)",
-            }}
-          >
-            <Clipboard.Indicator copied={<FiCheck />}>
-              <FiLink />
-            </Clipboard.Indicator>
-            {iconOnly ? null : (
-              <Clipboard.Indicator copied={"Copied"}>
-                {"Copy link"}
+    <Tooltip
+      content={"Copy link"}
+      showArrow
+      closeOnScroll
+      positioning={{ placement: "bottom" }}
+    >
+      <span>
+        <Clipboard.Root value={currentUrl} timeout={1000}>
+          <Clipboard.Trigger asChild>
+            <HStack
+              as="button"
+              type="button"
+              gap={iconOnly ? 0 : 2}
+              fontFamily="ui"
+              fontSize="sm"
+              color="app.fg.subtle"
+              cursor="pointer"
+              px={iconOnly ? 2 : 3}
+              py={iconOnly ? 2 : 1.5}
+              rounded="full"
+              borderWidth="1px"
+              borderColor="app.border.default"
+              bg="app.bg.default"
+              transition="all 0.16s ease"
+              minH={iconOnly ? 8 : 10}
+              minW={iconOnly ? 8 : 10}
+              _hover={{
+                color: "app.fg.default",
+                borderColor: "app.fg.icon",
+                bg: "app.bg.subtle",
+                transform: "translateY(-1px)",
+              }}
+            >
+              <Clipboard.Indicator copied={<FiCheck />}>
+                <FiLink />
               </Clipboard.Indicator>
-            )}
-          </HStack>
-        </Clipboard.Trigger>
-      </Clipboard.Root>
+              {iconOnly ? null : (
+                <Clipboard.Indicator copied={"Copied"}>
+                  {"Copy link"}
+                </Clipboard.Indicator>
+              )}
+            </HStack>
+          </Clipboard.Trigger>
+        </Clipboard.Root>
+      </span>
     </Tooltip>
   );
 }

--- a/src/components/page/common/CopyLinkSecondaryButton.tsx
+++ b/src/components/page/common/CopyLinkSecondaryButton.tsx
@@ -51,6 +51,7 @@ export default function CopyLinkSecondaryButton({
                 bg: "app.bg.subtle",
                 transform: "translateY(-1px)",
               }}
+              aria-label="Copy link"
             >
               <Clipboard.Indicator copied={<FiCheck />}>
                 <FiLink />

--- a/src/components/page/common/DetailPage.tsx
+++ b/src/components/page/common/DetailPage.tsx
@@ -9,7 +9,13 @@ import type { ReactNode } from "react";
 
 export function DetailTitleBar({ title }: { title: string }) {
   return (
-    <Box mx={[4, 6]} mt={4} letterSpacing={"wide"} position={"relative"}>
+    <Box
+      as="header"
+      mx={[4, 6]}
+      mt={4}
+      letterSpacing={"wide"}
+      position={"relative"}
+    >
       <Box pr={12}>
         <Heading1>{title}</Heading1>
       </Box>

--- a/src/components/page/common/DetailPage.tsx
+++ b/src/components/page/common/DetailPage.tsx
@@ -30,7 +30,7 @@ export function DetailMetaSection({ children }: { children: ReactNode }) {
 
 export function DetailDescription({ description }: { description: string }) {
   return (
-    <Text fontSize="sm" color="gray.500">
+    <Text fontSize="sm" color="app.fg.muted">
       {description}
     </Text>
   );

--- a/src/components/page/common/Footer.tsx
+++ b/src/components/page/common/Footer.tsx
@@ -96,32 +96,34 @@ export default function Footer({
                 >
                   Connect
                 </Text>
-                <HStack gap={3}>
-                  {socialLinks.map((social) => (
-                    <Tooltip
-                      key={social.label}
-                      content={social.tooltip}
-                      showArrow
-                    >
-                      <Link
-                        href={social.href}
-                        target={social.isExternal ? "_blank" : undefined}
-                        rel={
-                          social.isExternal ? "noopener noreferrer" : undefined
-                        }
-                        aria-label={
-                          social.isExternal
-                            ? `${social.label} (opens in a new tab)`
-                            : social.label
-                        }
-                        color={social.color}
-                        _hover={{ opacity: 0.85 }}
+                <Box as="address" fontStyle="normal" m={0}>
+                  <HStack gap={3}>
+                    {socialLinks.map((social) => (
+                      <Tooltip
+                        key={social.label}
+                        content={social.tooltip}
+                        showArrow
                       >
-                        <Icon as={social.icon} boxSize={5} />
-                      </Link>
-                    </Tooltip>
-                  ))}
-                </HStack>
+                        <Link
+                          href={social.href}
+                          target={social.isExternal ? "_blank" : undefined}
+                          rel={
+                            social.isExternal ? "noopener noreferrer" : undefined
+                          }
+                          aria-label={
+                            social.isExternal
+                              ? `${social.label} (opens in a new tab)`
+                              : social.label
+                          }
+                          color={social.color}
+                          _hover={{ opacity: 0.85 }}
+                        >
+                          <Icon as={social.icon} boxSize={5} />
+                        </Link>
+                      </Tooltip>
+                    ))}
+                  </HStack>
+                </Box>
               </VStack>
 
               <VStack align="flex-start" gap={2} flex={1} minW={0}>

--- a/src/components/page/common/Footer.tsx
+++ b/src/components/page/common/Footer.tsx
@@ -13,16 +13,8 @@ import { HeaderCard } from "@components/core/Cards";
 import { Tooltip } from "@components/ui/tooltip";
 import { homepageTabs } from "app/route-info";
 import { PersonalData } from "data";
-import {
-  FiGithub,
-  FiHeart,
-  FiInstagram,
-  FiLinkedin,
-  FiMail,
-  FiSun,
-} from "react-icons/fi";
+import { FiGithub, FiInstagram, FiLinkedin, FiMail } from "react-icons/fi";
 import { FaXTwitter } from "react-icons/fa6";
-import { IoSnowOutline } from "react-icons/io5";
 
 const footerLinkProps = {
   fontSize: "sm",
@@ -40,14 +32,6 @@ export default function Footer({
 }: {
   hideBottomPart?: boolean;
 }) {
-  const currentMonth = new Date().getMonth();
-  const seasonalArtifact =
-    currentMonth >= 11 || currentMonth <= 1
-      ? { label: "Winter artifact", icon: IoSnowOutline }
-      : currentMonth >= 2 && currentMonth <= 4
-        ? { label: "Spring artifact", icon: FiHeart }
-        : { label: "Sunny artifact", icon: FiSun };
-
   const socialLinks = [
     {
       label: "LinkedIn",
@@ -198,20 +182,14 @@ export default function Footer({
               py={3}
               borderBottomRadius={"2xl"}
             >
-              <HStack
-                justify={"center"}
-                gap={2}
+              <Text
                 fontSize={"sm"}
                 fontWeight={"normal"}
                 color={"app.fg.icon"}
+                textAlign={"center"}
               >
-                <Icon
-                  as={seasonalArtifact.icon}
-                  aria-label={seasonalArtifact.label}
-                  boxSize={4}
-                />
-                <Text as="span">{PersonalData.name.full}</Text>
-              </HStack>
+                {PersonalData.name.full}
+              </Text>
             </Box>
           )}
         </VStack>

--- a/src/components/page/common/Footer.tsx
+++ b/src/components/page/common/Footer.tsx
@@ -191,7 +191,7 @@ export default function Footer({
               <Text
                 fontSize={"sm"}
                 fontWeight={"normal"}
-                color={"app.fg.icon"}
+                color={"app.fg.default"}
                 textAlign={"center"}
               >
                 {PersonalData.name.full}

--- a/src/components/page/common/Footer.tsx
+++ b/src/components/page/common/Footer.tsx
@@ -13,8 +13,16 @@ import { HeaderCard } from "@components/core/Cards";
 import { Tooltip } from "@components/ui/tooltip";
 import { homepageTabs } from "app/route-info";
 import { PersonalData } from "data";
-import { FiGithub, FiInstagram, FiLinkedin, FiMail } from "react-icons/fi";
+import {
+  FiGithub,
+  FiHeart,
+  FiInstagram,
+  FiLinkedin,
+  FiMail,
+  FiSun,
+} from "react-icons/fi";
 import { FaXTwitter } from "react-icons/fa6";
+import { IoSnowOutline } from "react-icons/io5";
 
 const footerLinkProps = {
   fontSize: "sm",
@@ -32,6 +40,14 @@ export default function Footer({
 }: {
   hideBottomPart?: boolean;
 }) {
+  const currentMonth = new Date().getMonth();
+  const seasonalArtifact =
+    currentMonth >= 11 || currentMonth <= 1
+      ? { label: "Winter artifact", icon: IoSnowOutline }
+      : currentMonth >= 2 && currentMonth <= 4
+        ? { label: "Spring artifact", icon: FiHeart }
+        : { label: "Sunny artifact", icon: FiSun };
+
   const socialLinks = [
     {
       label: "LinkedIn",
@@ -182,14 +198,20 @@ export default function Footer({
               py={3}
               borderBottomRadius={"2xl"}
             >
-              <Text
+              <HStack
+                justify={"center"}
+                gap={2}
                 fontSize={"sm"}
                 fontWeight={"normal"}
                 color={"app.fg.icon"}
-                textAlign={"center"}
               >
-                {PersonalData.name.full}
-              </Text>
+                <Icon
+                  as={seasonalArtifact.icon}
+                  aria-label={seasonalArtifact.label}
+                  boxSize={4}
+                />
+                <Text as="span">{PersonalData.name.full}</Text>
+              </HStack>
             </Box>
           )}
         </VStack>

--- a/src/components/page/common/Footer.tsx
+++ b/src/components/page/common/Footer.tsx
@@ -106,8 +106,14 @@ export default function Footer({
                       <Link
                         href={social.href}
                         target={social.isExternal ? "_blank" : undefined}
-                        rel={social.isExternal ? "noreferrer" : undefined}
-                        aria-label={social.label}
+                        rel={
+                          social.isExternal ? "noopener noreferrer" : undefined
+                        }
+                        aria-label={
+                          social.isExternal
+                            ? `${social.label} (opens in a new tab)`
+                            : social.label
+                        }
                         color={social.color}
                         _hover={{ opacity: 0.85 }}
                       >

--- a/src/components/page/common/Header.tsx
+++ b/src/components/page/common/Header.tsx
@@ -179,7 +179,7 @@ export default function Header() {
                 />
               </HStack>
             ) : (
-              <HStack gap={4}>
+              <HStack as={"nav"} aria-label={"Primary navigation"} gap={4}>
                 {navItems.map((item) => (
                   <HeaderNavIconButton
                     key={item.tab.pathname}
@@ -201,6 +201,7 @@ export default function Header() {
           {isMobile && !isPathnameDeep && isMobileMenuOpen ? (
             <Stack
               as={"nav"}
+              id={"mobile-navigation-menu"}
               aria-label={"Mobile navigation menu"}
               borderTopWidth={2}
               borderColor={"app.border.default"}

--- a/src/components/page/common/Header.tsx
+++ b/src/components/page/common/Header.tsx
@@ -148,6 +148,8 @@ export default function Header() {
 
   return (
     <Box
+      as="header"
+      role="banner"
       position={"fixed"}
       width={"100%"}
       maxW={"3xl"}

--- a/src/components/page/common/Header.tsx
+++ b/src/components/page/common/Header.tsx
@@ -222,7 +222,10 @@ export default function Header() {
                     variant={isSelected ? "surface" : "ghost"}
                     color={isSelected ? "app.fg.default" : "app.fg.subtle"}
                   >
-                    <NextLink href={item.tab.pathname}>
+                    <NextLink
+                      href={item.tab.pathname}
+                      aria-current={isSelected ? "page" : undefined}
+                    >
                       <HStack gap={2}>
                         <Icon as={item.icon} boxSize={6} />
                         <Heading6>{item.tab.name}</Heading6>

--- a/src/components/page/common/LinkedInPrimaryButton.tsx
+++ b/src/components/page/common/LinkedInPrimaryButton.tsx
@@ -16,7 +16,7 @@ export default function LinkedInButton() {
         href={PersonalData.linkedIn.url}
         target="_blank"
         rel="noopener noreferrer"
-        aria-label={"Open LinkedIn profile"}
+        aria-label={"Open LinkedIn profile (opens in a new tab)"}
         icon={FaLinkedin}
         backgroundColor={"app.brand.linkedin.solid"}
       >
@@ -40,7 +40,7 @@ export function LinkedInButtonSmall() {
         rel="noopener noreferrer"
         rounded={"full"}
         colorScheme="blue"
-        aria-label={"Open LinkedIn profile"}
+        aria-label={"Open LinkedIn profile (opens in a new tab)"}
       >
         <Icon>
           <FaLinkedin />

--- a/src/components/page/common/header/HeaderMobileTrigger.tsx
+++ b/src/components/page/common/header/HeaderMobileTrigger.tsx
@@ -21,6 +21,8 @@ export default function HeaderMobileTrigger({
       borderWidth={2}
       variant={isOpen ? "surface" : "outline"}
       transition={"width 0.24s ease"}
+      aria-expanded={isOpen}
+      aria-controls={"mobile-navigation-menu"}
       aria-label={
         isOpen ? "Close mobile navigation menu" : "Open mobile navigation menu"
       }

--- a/src/components/page/common/header/HeaderNavIconButton.tsx
+++ b/src/components/page/common/header/HeaderNavIconButton.tsx
@@ -1,7 +1,6 @@
 import { Icon, IconButton } from "@chakra-ui/react";
 import NextLink from "next/link";
 import type { IconType } from "react-icons";
-import { useColorModeValue } from "@components/ui/color-mode";
 import { Tooltip } from "@components/ui/tooltip";
 
 export default function HeaderNavIconButton({
@@ -19,18 +18,23 @@ export default function HeaderNavIconButton({
 }) {
   return (
     <Tooltip content={label} closeOnScroll>
-      <NextLink href={url ?? ""} onClick={onClick}>
-        <IconButton
-          borderRadius={"full"}
-          borderWidth={isSelected ? "thin" : 0}
-          borderColor={"app.border.default"}
-          variant={isSelected ? "surface" : "ghost"}
-          color={isSelected ? "app.fg.default" : "app.fg.subtle"}
+      <IconButton
+        asChild
+        borderRadius={"full"}
+        borderWidth={isSelected ? "thin" : 0}
+        borderColor={"app.border.default"}
+        variant={isSelected ? "surface" : "ghost"}
+        color={isSelected ? "app.fg.default" : "app.fg.subtle"}
+      >
+        <NextLink
+          href={url ?? ""}
+          onClick={onClick}
           aria-label={label}
+          aria-current={isSelected ? "page" : undefined}
         >
           <Icon boxSize={6} as={icon} />
-        </IconButton>
-      </NextLink>
+        </NextLink>
+      </IconButton>
     </Tooltip>
   );
 }

--- a/src/components/page/cv/CvAccomplishmentsSection.tsx
+++ b/src/components/page/cv/CvAccomplishmentsSection.tsx
@@ -86,6 +86,7 @@ function AccomplishmentCard({
                   href={item.url}
                   target="_blank"
                   rel="noopener noreferrer"
+                  aria-label={`Open ${item.title} credential (opens in a new tab)`}
                   fontSize={CV_META_TEXT_SIZE}
                   color={CV_SECONDARY_TEXT_COLOR}
                   fontFamily={CV_CMU_FONT_FAMILY}

--- a/src/components/page/cv/CvSkillsSection.tsx
+++ b/src/components/page/cv/CvSkillsSection.tsx
@@ -29,7 +29,7 @@ function SkillLevel({
   const inactiveColor = "app.border.default";
 
   return (
-    <HStack gap={1} aria-label={`${label} proficiency`} title={label}>
+    <HStack gap={1} role="img" aria-label={`${label} proficiency`} title={label}>
       {Array.from({ length: 4 }).map((_, index) => {
         const isActive = index < activeCount;
         return (

--- a/src/components/page/wrapper/WithBodyCard.tsx
+++ b/src/components/page/wrapper/WithBodyCard.tsx
@@ -14,6 +14,7 @@ export default function WithBodyCard({
       as="main"
       id="main-content"
       tabIndex={-1}
+      scrollMarginTop={{ base: "6rem", sm: "7rem" }}
       px={[1, 4]}
       pt={[1, 2]}
       pb={[1, 1]}

--- a/src/components/page/wrapper/WithBodyCard.tsx
+++ b/src/components/page/wrapper/WithBodyCard.tsx
@@ -10,7 +10,15 @@ export default function WithBodyCard({
   containerProps?: BoxProps;
 }) {
   return (
-    <Box px={[1, 4]} pt={[1, 2]} pb={[1, 1]} {...containerProps}>
+    <Box
+      as="main"
+      id="main-content"
+      tabIndex={-1}
+      px={[1, 4]}
+      pt={[1, 2]}
+      pb={[1, 1]}
+      {...containerProps}
+    >
       <MainCard>
         <VStack align={"stretch"}>{children}</VStack>
       </MainCard>

--- a/src/components/ui/avatar.tsx
+++ b/src/components/ui/avatar.tsx
@@ -24,7 +24,12 @@ export const Avatar = React.forwardRef<HTMLDivElement, AvatarProps>(
         <ChakraAvatar.Fallback name={name}>
           {icon || fallback}
         </ChakraAvatar.Fallback>
-        <ChakraAvatar.Image src={src} srcSet={srcSet} loading={loading} />
+        <ChakraAvatar.Image
+          src={src}
+          srcSet={srcSet}
+          loading={loading}
+          alt={name ?? ""}
+        />
         {children}
       </ChakraAvatar.Root>
     )

--- a/src/features/epub-maker/components/EpubMetadataForm.tsx
+++ b/src/features/epub-maker/components/EpubMetadataForm.tsx
@@ -157,6 +157,7 @@ export function EpubMetadataForm({
           >
             <Box
               as={"span"}
+              role={"img"}
               aria-label={"About embed remote images"}
               color={"app.epub.fg.muted"}
               cursor={"help"}
@@ -184,6 +185,7 @@ export function EpubMetadataForm({
           >
             <Box
               as={"span"}
+              role={"img"}
               aria-label={"About keep external links"}
               color={"app.epub.fg.muted"}
               cursor={"help"}

--- a/src/features/epub-maker/components/EpubToolbar.tsx
+++ b/src/features/epub-maker/components/EpubToolbar.tsx
@@ -141,6 +141,7 @@ export function EpubToolbar({
           <FileUpload.Root maxFiles={50}>
             <FileUpload.HiddenInput
               ref={uploadInputRef}
+              aria-label={"Upload files"}
               onChange={handleUploadInputChange}
             />
             <Tooltip content={"Upload files"}>

--- a/src/features/epub-maker/components/PageDraftGrid.tsx
+++ b/src/features/epub-maker/components/PageDraftGrid.tsx
@@ -376,6 +376,7 @@ export function PageDraftGrid({
             <FileUpload.Root maxFiles={50}>
               <FileUpload.HiddenInput
                 ref={ghostUploadInputRef}
+                aria-label={"Upload files"}
                 onChange={handleGhostUploadChange}
               />
               <Button

--- a/src/features/tools/components/ToolCard.tsx
+++ b/src/features/tools/components/ToolCard.tsx
@@ -1,7 +1,6 @@
 import { HStack, Icon, Text, VStack } from "@chakra-ui/react";
 import { CategoryBadge, FeaturedIndicator } from "@components/core/Badges";
 import { InnerBgCardWithHeader } from "@components/core/Cards";
-import { Heading5 } from "@components/core/Texts";
 import NextLink from "next/link";
 import { FiBookOpen, FiChevronRight, FiTool } from "react-icons/fi";
 import type { ToolDefinition } from "../types";
@@ -33,7 +32,9 @@ export function ToolCard({ tool }: { tool: ToolDefinition }) {
             <VStack align={"start"} gap={1}>
               <HStack gap={2} align={"center"}>
                 <Icon as={ToolIcon} boxSize={5} color={"app.fg.subtle"} />
-                <Heading5>{tool.name}</Heading5>
+                <Text fontSize={"md"} fontWeight={"medium"} color={"app.fg.default"}>
+                  {tool.name}
+                </Text>
                 {tool.isFeatured ? <FeaturedIndicator /> : null}
               </HStack>
               <Text color={"app.fg.subtle"} fontSize={"sm"}>

--- a/src/features/tools/components/ToolsDirectoryPage.tsx
+++ b/src/features/tools/components/ToolsDirectoryPage.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Box, EmptyState, Heading, HStack, Icon, Text, VStack } from "@chakra-ui/react";
+import { Box, EmptyState, HStack, Icon, Text, VStack } from "@chakra-ui/react";
 import { CategoryBadge, FeaturedIndicator } from "@components/core/Badges";
 import { Heading1, SubtitleText } from "@components/core/Texts";
 import { TileList } from "@components/core/Tiles";
@@ -47,14 +47,14 @@ function ToolListTile({ tool }: { tool: ToolDefinition }) {
             <VStack align={"start"} gap={0}>
               <HStack gap={2} align={"center"}>
                 <Icon as={ToolIcon} boxSize={5} color={"app.fg.subtle"} />
-                <Heading
-                  as={"h4"}
+                <Text
                   fontSize={"lg"}
                   fontWeight={"medium"}
                   fontFamily={"heading"}
+                  color={"app.fg.default"}
                 >
                   {tool.name}
-                </Heading>
+                </Text>
                 {tool.isFeatured ? <FeaturedIndicator /> : null}
               </HStack>
               <Text color={"app.fg.subtle"} fontFamily={"body"}>

--- a/tests/a11y/pages.spec.ts
+++ b/tests/a11y/pages.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from "@playwright/test";
+import AxeBuilder from "@axe-core/playwright";
+
+const pages = [
+  "/",
+  "/projects",
+  "/blogs/character-encodings-and-unicode",
+];
+
+for (const path of pages) {
+  test(`axe: ${path} has no serious accessibility violations`, async ({ page }) => {
+    await page.goto(path);
+    await page.waitForLoadState("networkidle");
+
+    const results = await new AxeBuilder({ page })
+      .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa", "wcag22aa"])
+      .analyze();
+
+    const seriousOrWorse = results.violations.filter((violation) =>
+      ["serious", "critical"].includes(violation.impact ?? ""),
+    );
+
+    expect(
+      seriousOrWorse,
+      seriousOrWorse
+        .map((v) => `${v.id}: ${v.help} (${v.nodes.length} node(s))`)
+        .join("\n"),
+    ).toEqual([]);
+  });
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -72,6 +72,13 @@
     "@zag-js/types" "1.31.1"
     "@zag-js/utils" "1.31.1"
 
+"@axe-core/playwright@^4.11.1":
+  version "4.11.1"
+  resolved "https://registry.yarnpkg.com/@axe-core/playwright/-/playwright-4.11.1.tgz#d6e2b06ddb1b8ff460ca0f6f0bc96f2f03f6d91b"
+  integrity sha512-mKEfoUIB1MkVTht0BGZFXtSAEKXMJoDkyV5YZ9jbBmZCcWDz71tegNsdTkIN8zc/yMi5Gm2kx7Z5YQ9PfWNAWw==
+  dependencies:
+    axe-core "~4.11.1"
+
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.28.6", "@babel/code-frame@^7.29.0":
   version "7.29.0"
   resolved "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz"
@@ -743,6 +750,13 @@
   version "1.8.1"
   resolved "https://registry.npmjs.org/@pandacss/is-valid-prop/-/is-valid-prop-1.8.1.tgz"
   integrity sha512-gf2HTBCOboc65Jlb9swAjbffXSIv+A4vzSQ9iHyTCDLMcXTHYjPOQNliI36WkuQgR0pNXggBbQXGNaT9wKcrAw==
+
+"@playwright/test@^1.58.2":
+  version "1.58.2"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.58.2.tgz#b0ad585d2e950d690ef52424967a42f40c6d2cbd"
+  integrity sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==
+  dependencies:
+    playwright "1.58.2"
 
 "@rtsao/scc@^1.1.0":
   version "1.1.0"
@@ -1954,9 +1968,14 @@ available-typed-arrays@^1.0.7:
   dependencies:
     possible-typed-array-names "^1.0.0"
 
-axe-core@^4.10.0:
+axe-core@^4.10.0, axe-core@~4.11.1:
   version "4.11.1"
   resolved "https://registry.npmjs.org/axe-core/-/axe-core-4.11.1.tgz"
+  integrity sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A==
+
+axe-core@^4.11.1:
+  version "4.11.1"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.11.1.tgz#052ff9b2cbf543f5595028b583e4763b40c78ea7"
   integrity sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A==
 
 axobject-query@^4.1.0:
@@ -2765,6 +2784,11 @@ for-each@^0.3.3, for-each@^0.3.5:
   integrity sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==
   dependencies:
     is-callable "^1.2.7"
+
+fsevents@2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
+  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
 
 function-bind@^1.1.2:
   version "1.1.2"
@@ -4272,6 +4296,20 @@ picomatch@^4.0.3:
   version "4.0.3"
   resolved "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz"
   integrity sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==
+
+playwright-core@1.58.2:
+  version "1.58.2"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.58.2.tgz#ac5f5b4b10d29bcf934415f0b8d133b34b0dcb13"
+  integrity sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==
+
+playwright@1.58.2:
+  version "1.58.2"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.58.2.tgz#afe547164539b0bcfcb79957394a7a3fa8683cfd"
+  integrity sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==
+  dependencies:
+    playwright-core "1.58.2"
+  optionalDependencies:
+    fsevents "2.3.2"
 
 possible-typed-array-names@^1.0.0:
   version "1.1.0"


### PR DESCRIPTION
## Summary
This PR now contains only accessibility-focused fixes for issue #69.

## What was changed
- Added a keyboard skip link (`Skip to main content`) with visible focus styling.
- Added a real main landmark with focus target (`id=main-content`, `tabIndex=-1`).
- Improved navigation semantics:
- Added desktop `nav` landmark label.
- Added mobile trigger state semantics (`aria-expanded`, `aria-controls`).
- Added `id` for mobile nav container.
- Fixed image accessibility bug: image block now respects provided `alt` text (falls back to caption).
- Reduced heading-structure noise: section label now renders as paragraph text instead of heading.

## Verification
- `yarn build` passes successfully.

## Issue coverage
- Addresses #69 (Accessibility Review)
