### PR TITLE
Fix #71 README updates and #72 LinkedIn mobile button color

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 This repository contains code for a personal website.
 
+## Features
+
+- Home, About, CV, Blogs, Projects, and Tools sections
+- Blog posts authored in Markdown (`src/data/blogs/markdown`)
+- Project detail pages authored in Markdown (`src/data/projects/markdown`)
+- Dedicated tools area for utility pages
+
 ## Stack
 
 Built with [Next.js](https://nextjs.org/) 16, [React](https://react.dev/) 19, [Chakra UI](https://chakra-ui.com/) v3, and TypeScript.
@@ -20,6 +27,12 @@ The main code lives in:
 
 `next.config.ts` is configured for static export (`output: "export"`).
 Running `next build` generates static files that can be hosted on any static file server.
+
+This repo deploys to GitHub Pages via GitHub Actions (`.github/workflows/nextjs.yml`):
+
+- Trigger: pushes to `main` (and manual `workflow_dispatch`)
+- Build: install dependencies and run `next build`
+- Publish: upload `./out` as Pages artifact and deploy with `actions/deploy-pages`
 
 ## Design
 

--- a/src/components/page/common/LinkedInPrimaryButton.tsx
+++ b/src/components/page/common/LinkedInPrimaryButton.tsx
@@ -39,7 +39,9 @@ export function LinkedInButtonSmall() {
         target="_blank"
         rel="noopener noreferrer"
         rounded={"full"}
-        colorScheme="blue"
+        color={"app.brand.linkedin.contrast"}
+        backgroundColor={"app.brand.linkedin.solid"}
+        _hover={{ opacity: 0.9 }}
         aria-label={"Open LinkedIn profile (opens in a new tab)"}
       >
         <Icon>


### PR DESCRIPTION
## Summary
- update README feature section to reflect current site capabilities
- document GitHub Actions based Pages deployment flow
- remove explicit tool name mention from README feature bullet
- fix LinkedIn mobile icon button styling so background stays LinkedIn brand blue
- make mobile LinkedIn icon color theme-aware via semantic contrast token

## Why
- resolves stale/incomplete README information noted in #71
- resolves mobile LinkedIn button color inconsistency noted in #72

## Changes
### Issue #71
- expanded Features section with tools/projects/blog markdown support
- added deployment details referencing `.github/workflows/nextjs.yml`
- generalized tools wording to avoid naming a specific tool

### Issue #72
- updated `LinkedInButtonSmall` in `src/components/page/common/LinkedInPrimaryButton.tsx`
- replaced `colorScheme="blue"` behavior with explicit brand background token
- used `app.brand.linkedin.contrast` for icon foreground to match light/dark theme expectations

## Validation
- manual review of button token usage in desktop and mobile variants
- ensured README reflects current architecture and deployment behavior

Closes #71
Closes #72