### PR TITLE
Fix issue #76: reusable shortcut keycap hints

### DIFF
--- a/src/components/core/ShortcutHint.tsx
+++ b/src/components/core/ShortcutHint.tsx
@@ -10,10 +10,20 @@ type ShortcutHintProps = {
 export function ShortcutHint({ label, icon, shape = "default" }: ShortcutHintProps) {
   const isSquare = shape === "square";
 
+  const content = (
+    <>
+      {icon ? <Icon as={icon} boxSize={3} /> : null}
+      <Text as={"span"} color={"inherit"} textTransform={"uppercase"} lineHeight={1}>
+        {label}
+      </Text>
+    </>
+  );
+
   if (isSquare) {
     return (
       <AspectRatio ratio={1} w={"1.35rem"} flexShrink={0}>
         <Box
+          as={"kbd"}
           w={"full"}
           h={"full"}
           display={"inline-flex"}
@@ -21,15 +31,17 @@ export function ShortcutHint({ label, icon, shape = "default" }: ShortcutHintPro
           justifyContent={"center"}
           rounded={"md"}
           borderWidth={"1px"}
-          borderColor={"inherit"}
+          borderBottomWidth={"3px"}
+          borderColor={"currentColor"}
+          bg={"color-mix(in srgb, currentColor 10%, transparent)"}
           color={"inherit"}
           fontSize={"xs"}
           fontWeight={"semibold"}
           lineHeight={1}
+          letterSpacing={"tight"}
+          userSelect={"none"}
         >
-          <Text as={"span"} color={"inherit"}>
-            {label}
-          </Text>
+          {content}
         </Box>
       </AspectRatio>
     );
@@ -37,20 +49,24 @@ export function ShortcutHint({ label, icon, shape = "default" }: ShortcutHintPro
 
   return (
     <HStack
-      minH={"1.5rem"}
+      as={"kbd"}
+      minH={"1.6rem"}
       px={1.5}
       rounded={"md"}
       borderWidth={"1px"}
+      borderBottomWidth={"3px"}
       borderColor={"currentColor"}
-      opacity={0.75}
+      bg={"color-mix(in srgb, currentColor 10%, transparent)"}
+      opacity={0.85}
       fontSize={"2xs"}
       fontWeight={"semibold"}
       gap={1}
       lineHeight={1}
       flexShrink={0}
+      letterSpacing={"tight"}
+      userSelect={"none"}
     >
-      {icon ? <Icon as={icon} boxSize={3} /> : null}
-      <Text as={"span"}>{label}</Text>
+      {content}
     </HStack>
   );
 }

--- a/src/components/core/ShortcutHint.tsx
+++ b/src/components/core/ShortcutHint.tsx
@@ -5,9 +5,15 @@ type ShortcutHintProps = {
   label: string;
   icon?: IconType;
   shape?: "default" | "square";
+  pressed?: boolean;
 };
 
-export function ShortcutHint({ label, icon, shape = "default" }: ShortcutHintProps) {
+export function ShortcutHint({
+  label,
+  icon,
+  shape = "default",
+  pressed = false,
+}: ShortcutHintProps) {
   const isSquare = shape === "square";
 
   const content = (
@@ -31,7 +37,7 @@ export function ShortcutHint({ label, icon, shape = "default" }: ShortcutHintPro
           justifyContent={"center"}
           rounded={"md"}
           borderWidth={"1px"}
-          borderBottomWidth={"3px"}
+          borderBottomWidth={pressed ? "1px" : "3px"}
           borderColor={"currentColor"}
           bg={"color-mix(in srgb, currentColor 10%, transparent)"}
           color={"inherit"}
@@ -40,6 +46,8 @@ export function ShortcutHint({ label, icon, shape = "default" }: ShortcutHintPro
           lineHeight={1}
           letterSpacing={"tight"}
           userSelect={"none"}
+          transform={pressed ? "translateY(2px)" : undefined}
+          transition={"transform 0.12s ease, border-bottom-width 0.12s ease"}
         >
           {content}
         </Box>
@@ -54,7 +62,7 @@ export function ShortcutHint({ label, icon, shape = "default" }: ShortcutHintPro
       px={1.5}
       rounded={"md"}
       borderWidth={"1px"}
-      borderBottomWidth={"3px"}
+      borderBottomWidth={pressed ? "1px" : "3px"}
       borderColor={"currentColor"}
       bg={"color-mix(in srgb, currentColor 10%, transparent)"}
       opacity={0.85}
@@ -65,6 +73,8 @@ export function ShortcutHint({ label, icon, shape = "default" }: ShortcutHintPro
       flexShrink={0}
       letterSpacing={"tight"}
       userSelect={"none"}
+      transform={pressed ? "translateY(2px)" : undefined}
+      transition={"transform 0.12s ease, border-bottom-width 0.12s ease"}
     >
       {content}
     </HStack>

--- a/src/features/calendar-drill/components/CalendarDrillPage.tsx
+++ b/src/features/calendar-drill/components/CalendarDrillPage.tsx
@@ -13,6 +13,7 @@ import {
   Text,
   VStack,
 } from "@chakra-ui/react";
+import { ShortcutHint } from "@components/core/ShortcutHint";
 import { Switch } from "@components/ui/switch";
 import HighlightedSection from "@components/page/common/HighlightedSection";
 import { useEffect, useMemo, useState } from "react";
@@ -48,7 +49,6 @@ import {
 } from "./practice-utils";
 import { ChoiceButton } from "./ChoiceButton";
 import { SessionStatsCard } from "./SessionStatsCard";
-import { ShortcutHint } from "./ShortcutHint";
 
 const CALENDAR_DRILL_PRIMARY_ACTION_BUTTON_STYLES = {
   bg: "app.calendarDrill.button.primary.bg",

--- a/src/features/calendar-drill/components/ChoiceButton.tsx
+++ b/src/features/calendar-drill/components/ChoiceButton.tsx
@@ -1,7 +1,7 @@
 import { Box, Button, Icon, Text } from "@chakra-ui/react";
+import { ShortcutHint } from "@components/core/ShortcutHint";
 import { LuCircleCheck, LuCircleX } from "react-icons/lu";
 import type { WeekdayChoice } from "./models";
-import { ShortcutHint } from "./ShortcutHint";
 
 type ChoiceButtonProps = {
   choice: WeekdayChoice;


### PR DESCRIPTION
## Summary
- add a globally reusable `ShortcutHint` keycap component
- update Calendar Drill to use the shared shortcut hint
- add optional pressed-state styling for shortcut hints

Closes #76
