### PR TITLE
EPUB Maker cover workflow updates and shortcut hint reuse

### DIFF
--- a/src/features/epub-maker/components/EpubHelpButton.tsx
+++ b/src/features/epub-maker/components/EpubHelpButton.tsx
@@ -2,37 +2,15 @@ import {
   Box,
   Dialog,
   HStack,
-  Icon,
   IconButton,
   Separator,
   Text,
   VStack,
 } from "@chakra-ui/react";
+import { ShortcutHint } from "@components/core/ShortcutHint";
 import { DialogCloseTrigger, DialogContent } from "@components/ui/dialog";
 import { Tooltip } from "@components/ui/tooltip";
 import { LuCircleHelp, LuCommand } from "react-icons/lu";
-import type { IconType } from "react-icons";
-
-function ShortcutToken({ label, icon }: { label?: string; icon?: IconType }) {
-  return (
-    <HStack
-      minH={"1.75rem"}
-      px={2}
-      rounded={"md"}
-      borderWidth={"1px"}
-      borderColor={"app.epub.border.default"}
-      bg={"app.epub.bg.surface"}
-      color={"app.epub.fg.default"}
-      fontSize={"xs"}
-      fontWeight={"semibold"}
-      gap={1}
-      lineHeight={1}
-    >
-      {icon ? <Icon as={icon} boxSize={3.5} /> : null}
-      {label ? <Text>{label}</Text> : null}
-    </HStack>
-  );
-}
 
 function ShortcutJoiner({ value }: { value: string }) {
   return (
@@ -141,39 +119,39 @@ export function EpubHelpButton() {
                 <HStack justify={"space-between"}>
                   <Text color={"app.epub.fg.default"}>Paste and add page</Text>
                   <HStack gap={1}>
-                    <ShortcutToken icon={LuCommand} />
+                    <ShortcutHint icon={LuCommand} label={""} />
                     <ShortcutJoiner value={"/"} />
-                    <ShortcutToken label={"Ctrl"} />
+                    <ShortcutHint label={"Ctrl"} />
                     <ShortcutJoiner value={"+"} />
-                    <ShortcutToken label={"V"} />
+                    <ShortcutHint label={"V"} />
                   </HStack>
                 </HStack>
 
                 <HStack justify={"space-between"}>
                   <Text color={"app.epub.fg.default"}>Undo</Text>
                   <HStack gap={1}>
-                    <ShortcutToken icon={LuCommand} />
+                    <ShortcutHint icon={LuCommand} label={""} />
                     <ShortcutJoiner value={"/"} />
-                    <ShortcutToken label={"Ctrl"} />
+                    <ShortcutHint label={"Ctrl"} />
                     <ShortcutJoiner value={"+"} />
-                    <ShortcutToken label={"Z"} />
+                    <ShortcutHint label={"Z"} />
                   </HStack>
                 </HStack>
 
                 <HStack justify={"space-between"} align={"start"}>
                   <Text color={"app.epub.fg.default"}>Redo</Text>
                   <HStack gap={1} wrap={"wrap"} justify={"end"}>
-                    <ShortcutToken icon={LuCommand} />
+                    <ShortcutHint icon={LuCommand} label={""} />
                     <ShortcutJoiner value={"/"} />
-                    <ShortcutToken label={"Ctrl"} />
+                    <ShortcutHint label={"Ctrl"} />
                     <ShortcutJoiner value={"+"} />
-                    <ShortcutToken label={"Shift"} />
+                    <ShortcutHint label={"Shift"} />
                     <ShortcutJoiner value={"+"} />
-                    <ShortcutToken label={"Z"} />
+                    <ShortcutHint label={"Z"} />
                     <ShortcutJoiner value={"or"} />
-                    <ShortcutToken label={"Ctrl"} />
+                    <ShortcutHint label={"Ctrl"} />
                     <ShortcutJoiner value={"+"} />
-                    <ShortcutToken label={"Y"} />
+                    <ShortcutHint label={"Y"} />
                   </HStack>
                 </HStack>
               </VStack>

--- a/src/features/epub-maker/components/EpubHelpButton.tsx
+++ b/src/features/epub-maker/components/EpubHelpButton.tsx
@@ -103,8 +103,8 @@ export function EpubHelpButton() {
                   display={"list-item"}
                   color={"app.epub.fg.default"}
                 >
-                  Use the cover controls to include/exclude cover, upload a custom
-                  cover, or reset to auto cover (title + author).
+                  Use the cover controls to upload a custom cover image or reset to
+                  the auto cover (title + author).
                 </Text>
                 <Text
                   as={"li"}

--- a/src/features/epub-maker/components/EpubHelpButton.tsx
+++ b/src/features/epub-maker/components/EpubHelpButton.tsx
@@ -103,8 +103,8 @@ export function EpubHelpButton() {
                   display={"list-item"}
                   color={"app.epub.fg.default"}
                 >
-                  Use the cover controls to upload a custom cover image or reset to
-                  the auto cover (title + author).
+                  Use the cover controls to upload a custom cover image, reset to
+                  the auto cover (title + author), or disable cover export.
                 </Text>
                 <Text
                   as={"li"}

--- a/src/features/epub-maker/components/EpubHelpButton.tsx
+++ b/src/features/epub-maker/components/EpubHelpButton.tsx
@@ -103,7 +103,16 @@ export function EpubHelpButton() {
                   display={"list-item"}
                   color={"app.epub.fg.default"}
                 >
-                  Rename, reorder, or remove pages in the draft grid.
+                  Use the cover controls to include/exclude cover, upload a custom
+                  cover, or reset to auto cover (title + author).
+                </Text>
+                <Text
+                  as={"li"}
+                  display={"list-item"}
+                  color={"app.epub.fg.default"}
+                >
+                  Rename, reorder, or remove pages in the draft grid. Cover stays
+                  pinned first and cannot be dragged.
                 </Text>
                 <Text
                   as={"li"}

--- a/src/features/epub-maker/components/EpubMakerPageView.tsx
+++ b/src/features/epub-maker/components/EpubMakerPageView.tsx
@@ -144,8 +144,6 @@ export function EpubMakerPageView(props: UseEpubMakerReturn) {
             prefs={props.prefs}
             autoEpubFileName={props.autoEpubFileName}
             coverEnabled={props.coverEnabled}
-            coverMode={props.coverMode}
-            hasCustomCover={props.hasCustomCover}
             onTitleChange={props.setTitle}
             onAuthorChange={props.setAuthor}
             onManualFileNameChange={props.setManualFileName}
@@ -153,8 +151,6 @@ export function EpubMakerPageView(props: UseEpubMakerReturn) {
             onEmbedRemoteImagesChange={props.setEmbedRemoteImages}
             onAllowExternalLinksChange={props.setAllowExternalLinks}
             onCoverEnabledChange={props.setCoverEnabled}
-            onReplaceCoverFromFiles={props.replaceCoverFromFiles}
-            onResetCoverToAuto={props.resetCoverToAuto}
           />
         </VStack>
       </Box>
@@ -175,6 +171,7 @@ export function EpubMakerPageView(props: UseEpubMakerReturn) {
               pages={props.pages}
               coverEnabled={props.coverEnabled}
               coverPreviewHtml={props.coverPreviewHtml}
+              hasCustomCover={props.hasCustomCover}
               isAdding={props.isAdding}
               isGenerating={props.isGenerating}
               generationChapterStatusByPageId={props.generationChapterStatusByPageId}
@@ -184,6 +181,9 @@ export function EpubMakerPageView(props: UseEpubMakerReturn) {
               onRemove={props.removePage}
               onRename={props.renamePage}
               onReorder={props.reorderPages}
+              onReplaceCoverFromFiles={props.replaceCoverFromFiles}
+              onReplaceCoverFromClipboard={props.replaceCoverFromClipboard}
+              onResetCoverToAuto={props.resetCoverToAuto}
               onAddFromClipboard={props.addPageFromClipboard}
               onAddFromFiles={props.addPagesFromFiles}
               pastedInput={props.pastedInput}

--- a/src/features/epub-maker/components/EpubMakerPageView.tsx
+++ b/src/features/epub-maker/components/EpubMakerPageView.tsx
@@ -125,6 +125,7 @@ export function EpubMakerPageView(props: UseEpubMakerReturn) {
             generationProgress={props.generationProgress}
             showDownloadCompleteIcon={props.showDownloadCompleteIcon}
             pageCount={props.pages.length}
+            coverEnabled={props.coverEnabled}
             pastedInput={props.pastedInput}
             onAddFromClipboard={props.addPageFromClipboard}
             onAddFromFiles={props.addPagesFromFiles}
@@ -142,12 +143,18 @@ export function EpubMakerPageView(props: UseEpubMakerReturn) {
           <EpubMetadataForm
             prefs={props.prefs}
             autoEpubFileName={props.autoEpubFileName}
+            coverEnabled={props.coverEnabled}
+            coverMode={props.coverMode}
+            hasCustomCover={props.hasCustomCover}
             onTitleChange={props.setTitle}
             onAuthorChange={props.setAuthor}
             onManualFileNameChange={props.setManualFileName}
             onToggleFileNameMode={props.toggleFileNameMode}
             onEmbedRemoteImagesChange={props.setEmbedRemoteImages}
             onAllowExternalLinksChange={props.setAllowExternalLinks}
+            onCoverEnabledChange={props.setCoverEnabled}
+            onReplaceCoverFromFiles={props.replaceCoverFromFiles}
+            onResetCoverToAuto={props.resetCoverToAuto}
           />
         </VStack>
       </Box>
@@ -166,6 +173,8 @@ export function EpubMakerPageView(props: UseEpubMakerReturn) {
           <Box minH={"340px"} px={0} py={0}>
             <PageDraftGrid
               pages={props.pages}
+              coverEnabled={props.coverEnabled}
+              coverPreviewHtml={props.coverPreviewHtml}
               isAdding={props.isAdding}
               isGenerating={props.isGenerating}
               generationChapterStatusByPageId={props.generationChapterStatusByPageId}

--- a/src/features/epub-maker/components/EpubMakerPageView.tsx
+++ b/src/features/epub-maker/components/EpubMakerPageView.tsx
@@ -168,6 +168,7 @@ export function EpubMakerPageView(props: UseEpubMakerReturn) {
               pages={props.pages}
               coverPreviewHtml={props.coverPreviewHtml}
               hasCustomCover={props.hasCustomCover}
+              isCoverEnabled={props.isCoverEnabled}
               isAdding={props.isAdding}
               isGenerating={props.isGenerating}
               generationChapterStatusByPageId={props.generationChapterStatusByPageId}
@@ -180,6 +181,7 @@ export function EpubMakerPageView(props: UseEpubMakerReturn) {
               onReplaceCoverFromFiles={props.replaceCoverFromFiles}
               onReplaceCoverFromClipboard={props.replaceCoverFromClipboard}
               onResetCoverToAuto={props.resetCoverToAuto}
+              onToggleCoverEnabled={props.toggleCoverEnabled}
               onAddFromClipboard={props.addPageFromClipboard}
               onAddFromFiles={props.addPagesFromFiles}
               pastedInput={props.pastedInput}

--- a/src/features/epub-maker/components/EpubMakerPageView.tsx
+++ b/src/features/epub-maker/components/EpubMakerPageView.tsx
@@ -125,7 +125,6 @@ export function EpubMakerPageView(props: UseEpubMakerReturn) {
             generationProgress={props.generationProgress}
             showDownloadCompleteIcon={props.showDownloadCompleteIcon}
             pageCount={props.pages.length}
-            coverEnabled={props.coverEnabled}
             pastedInput={props.pastedInput}
             onAddFromClipboard={props.addPageFromClipboard}
             onAddFromFiles={props.addPagesFromFiles}
@@ -143,14 +142,12 @@ export function EpubMakerPageView(props: UseEpubMakerReturn) {
           <EpubMetadataForm
             prefs={props.prefs}
             autoEpubFileName={props.autoEpubFileName}
-            coverEnabled={props.coverEnabled}
             onTitleChange={props.setTitle}
             onAuthorChange={props.setAuthor}
             onManualFileNameChange={props.setManualFileName}
             onToggleFileNameMode={props.toggleFileNameMode}
             onEmbedRemoteImagesChange={props.setEmbedRemoteImages}
             onAllowExternalLinksChange={props.setAllowExternalLinks}
-            onCoverEnabledChange={props.setCoverEnabled}
           />
         </VStack>
       </Box>
@@ -169,7 +166,6 @@ export function EpubMakerPageView(props: UseEpubMakerReturn) {
           <Box minH={"340px"} px={0} py={0}>
             <PageDraftGrid
               pages={props.pages}
-              coverEnabled={props.coverEnabled}
               coverPreviewHtml={props.coverPreviewHtml}
               hasCustomCover={props.hasCustomCover}
               isAdding={props.isAdding}

--- a/src/features/epub-maker/components/EpubMetadataForm.tsx
+++ b/src/features/epub-maker/components/EpubMetadataForm.tsx
@@ -1,7 +1,6 @@
 import {
   Box,
   Button,
-  FileUpload,
   Group,
   HStack,
   Icon,
@@ -10,16 +9,13 @@ import {
 } from "@chakra-ui/react";
 import { Switch } from "@components/ui/switch";
 import { Tooltip } from "@components/ui/tooltip";
-import { type ChangeEvent, useRef } from "react";
-import { LuCircleHelp, LuRefreshCw, LuSettings2, LuUpload } from "react-icons/lu";
+import { LuCircleHelp, LuSettings2 } from "react-icons/lu";
 import type { EpubMakerState } from "../types";
 
 export function EpubMetadataForm({
   prefs,
   autoEpubFileName,
   coverEnabled,
-  coverMode,
-  hasCustomCover,
   onTitleChange,
   onAuthorChange,
   onManualFileNameChange,
@@ -27,14 +23,10 @@ export function EpubMetadataForm({
   onEmbedRemoteImagesChange,
   onAllowExternalLinksChange,
   onCoverEnabledChange,
-  onReplaceCoverFromFiles,
-  onResetCoverToAuto,
 }: {
   prefs: EpubMakerState["prefs"];
   autoEpubFileName: string;
   coverEnabled: boolean;
-  coverMode: EpubMakerState["coverMode"];
-  hasCustomCover: boolean;
   onTitleChange: (value: string) => void;
   onAuthorChange: (value: string) => void;
   onManualFileNameChange: (value: string) => void;
@@ -42,8 +34,6 @@ export function EpubMetadataForm({
   onEmbedRemoteImagesChange: (value: boolean) => void;
   onAllowExternalLinksChange: (value: boolean) => void;
   onCoverEnabledChange: (value: boolean) => void;
-  onReplaceCoverFromFiles: (files: FileList | File[]) => Promise<void>;
-  onResetCoverToAuto: () => void;
 }) {
   const controlInputProps = {
     fontFamily: "ui",
@@ -69,15 +59,6 @@ export function EpubMetadataForm({
       color: "app.epub.switch.label",
     },
   } as const;
-
-  const coverUploadInputRef = useRef<HTMLInputElement | null>(null);
-
-  function handleCoverUploadChange(event: ChangeEvent<HTMLInputElement>) {
-    const files = event.target.files;
-    if (!files || files.length === 0) return;
-    void onReplaceCoverFromFiles(files);
-    event.target.value = "";
-  }
 
   return (
     <>
@@ -228,50 +209,6 @@ export function EpubMetadataForm({
           >
             Include cover
           </Switch>
-          <Text fontSize={"xs"} color={"app.epub.fg.subtle"}>
-            {coverMode === "custom" ? "Custom" : "Auto"}
-          </Text>
-        </HStack>
-
-        <HStack gap={2} align={"center"}>
-          <FileUpload.Root maxFiles={1}>
-            <FileUpload.HiddenInput
-              ref={coverUploadInputRef}
-              aria-label={"Upload cover image"}
-              accept={"image/*"}
-              onChange={handleCoverUploadChange}
-            />
-            <Button
-              {...actionButtonProps}
-              size={"sm"}
-              variant={"subtle"}
-              bg={"app.epub.button.subtle.bg"}
-              color={"app.epub.button.subtle.fg"}
-              _hover={{ bg: "app.epub.button.subtle.hoverBg" }}
-              onClick={() => coverUploadInputRef.current?.click()}
-            >
-              <Icon>
-                <LuUpload />
-              </Icon>
-              Replace cover
-            </Button>
-          </FileUpload.Root>
-
-          <Button
-            {...actionButtonProps}
-            size={"sm"}
-            variant={"subtle"}
-            disabled={!hasCustomCover}
-            bg={"app.epub.button.subtle.bg"}
-            color={"app.epub.button.subtle.fg"}
-            _hover={{ bg: "app.epub.button.subtle.hoverBg" }}
-            onClick={onResetCoverToAuto}
-          >
-            <Icon>
-              <LuRefreshCw />
-            </Icon>
-            Reset cover
-          </Button>
         </HStack>
       </HStack>
     </>

--- a/src/features/epub-maker/components/EpubMetadataForm.tsx
+++ b/src/features/epub-maker/components/EpubMetadataForm.tsx
@@ -15,25 +15,21 @@ import type { EpubMakerState } from "../types";
 export function EpubMetadataForm({
   prefs,
   autoEpubFileName,
-  coverEnabled,
   onTitleChange,
   onAuthorChange,
   onManualFileNameChange,
   onToggleFileNameMode,
   onEmbedRemoteImagesChange,
   onAllowExternalLinksChange,
-  onCoverEnabledChange,
 }: {
   prefs: EpubMakerState["prefs"];
   autoEpubFileName: string;
-  coverEnabled: boolean;
   onTitleChange: (value: string) => void;
   onAuthorChange: (value: string) => void;
   onManualFileNameChange: (value: string) => void;
   onToggleFileNameMode: () => void;
   onEmbedRemoteImagesChange: (value: boolean) => void;
   onAllowExternalLinksChange: (value: boolean) => void;
-  onCoverEnabledChange: (value: boolean) => void;
 }) {
   const controlInputProps = {
     fontFamily: "ui",
@@ -201,15 +197,6 @@ export function EpubMetadataForm({
           </Tooltip>
         </HStack>
 
-        <HStack gap={2} align={"center"}>
-          <Switch
-            {...switchProps}
-            checked={coverEnabled}
-            onCheckedChange={(details) => onCoverEnabledChange(details.checked)}
-          >
-            Include cover
-          </Switch>
-        </HStack>
       </HStack>
     </>
   );

--- a/src/features/epub-maker/components/EpubMetadataForm.tsx
+++ b/src/features/epub-maker/components/EpubMetadataForm.tsx
@@ -1,6 +1,7 @@
 import {
   Box,
   Button,
+  FileUpload,
   Group,
   HStack,
   Icon,
@@ -9,27 +10,40 @@ import {
 } from "@chakra-ui/react";
 import { Switch } from "@components/ui/switch";
 import { Tooltip } from "@components/ui/tooltip";
-import { LuCircleHelp, LuSettings2 } from "react-icons/lu";
+import { type ChangeEvent, useRef } from "react";
+import { LuCircleHelp, LuRefreshCw, LuSettings2, LuUpload } from "react-icons/lu";
 import type { EpubMakerState } from "../types";
 
 export function EpubMetadataForm({
   prefs,
   autoEpubFileName,
+  coverEnabled,
+  coverMode,
+  hasCustomCover,
   onTitleChange,
   onAuthorChange,
   onManualFileNameChange,
   onToggleFileNameMode,
   onEmbedRemoteImagesChange,
   onAllowExternalLinksChange,
+  onCoverEnabledChange,
+  onReplaceCoverFromFiles,
+  onResetCoverToAuto,
 }: {
   prefs: EpubMakerState["prefs"];
   autoEpubFileName: string;
+  coverEnabled: boolean;
+  coverMode: EpubMakerState["coverMode"];
+  hasCustomCover: boolean;
   onTitleChange: (value: string) => void;
   onAuthorChange: (value: string) => void;
   onManualFileNameChange: (value: string) => void;
   onToggleFileNameMode: () => void;
   onEmbedRemoteImagesChange: (value: boolean) => void;
   onAllowExternalLinksChange: (value: boolean) => void;
+  onCoverEnabledChange: (value: boolean) => void;
+  onReplaceCoverFromFiles: (files: FileList | File[]) => Promise<void>;
+  onResetCoverToAuto: () => void;
 }) {
   const controlInputProps = {
     fontFamily: "ui",
@@ -55,6 +69,15 @@ export function EpubMetadataForm({
       color: "app.epub.switch.label",
     },
   } as const;
+
+  const coverUploadInputRef = useRef<HTMLInputElement | null>(null);
+
+  function handleCoverUploadChange(event: ChangeEvent<HTMLInputElement>) {
+    const files = event.target.files;
+    if (!files || files.length === 0) return;
+    void onReplaceCoverFromFiles(files);
+    event.target.value = "";
+  }
 
   return (
     <>
@@ -195,6 +218,60 @@ export function EpubMetadataForm({
               <LuCircleHelp />
             </Box>
           </Tooltip>
+        </HStack>
+
+        <HStack gap={2} align={"center"}>
+          <Switch
+            {...switchProps}
+            checked={coverEnabled}
+            onCheckedChange={(details) => onCoverEnabledChange(details.checked)}
+          >
+            Include cover
+          </Switch>
+          <Text fontSize={"xs"} color={"app.epub.fg.subtle"}>
+            {coverMode === "custom" ? "Custom" : "Auto"}
+          </Text>
+        </HStack>
+
+        <HStack gap={2} align={"center"}>
+          <FileUpload.Root maxFiles={1}>
+            <FileUpload.HiddenInput
+              ref={coverUploadInputRef}
+              aria-label={"Upload cover image"}
+              accept={"image/*"}
+              onChange={handleCoverUploadChange}
+            />
+            <Button
+              {...actionButtonProps}
+              size={"sm"}
+              variant={"subtle"}
+              bg={"app.epub.button.subtle.bg"}
+              color={"app.epub.button.subtle.fg"}
+              _hover={{ bg: "app.epub.button.subtle.hoverBg" }}
+              onClick={() => coverUploadInputRef.current?.click()}
+            >
+              <Icon>
+                <LuUpload />
+              </Icon>
+              Replace cover
+            </Button>
+          </FileUpload.Root>
+
+          <Button
+            {...actionButtonProps}
+            size={"sm"}
+            variant={"subtle"}
+            disabled={!hasCustomCover}
+            bg={"app.epub.button.subtle.bg"}
+            color={"app.epub.button.subtle.fg"}
+            _hover={{ bg: "app.epub.button.subtle.hoverBg" }}
+            onClick={onResetCoverToAuto}
+          >
+            <Icon>
+              <LuRefreshCw />
+            </Icon>
+            Reset cover
+          </Button>
         </HStack>
       </HStack>
     </>

--- a/src/features/epub-maker/components/EpubToolbar.tsx
+++ b/src/features/epub-maker/components/EpubToolbar.tsx
@@ -35,6 +35,7 @@ export function EpubToolbar({
   generationProgress,
   showDownloadCompleteIcon,
   pageCount,
+  coverEnabled,
   pastedInput,
   onAddFromClipboard,
   onAddFromFiles,
@@ -54,6 +55,7 @@ export function EpubToolbar({
   generationProgress: number | null;
   showDownloadCompleteIcon: boolean;
   pageCount: number;
+  coverEnabled: boolean;
   pastedInput: string;
   onAddFromClipboard: () => Promise<void>;
   onAddFromFiles: (files: FileList | File[]) => Promise<void>;
@@ -239,7 +241,7 @@ export function EpubToolbar({
         {...actionButtonProps}
         onClick={isGenerating ? onCancelGeneration : onGenerate}
         loading={false}
-        disabled={!isGenerating && pageCount === 0}
+        disabled={!isGenerating && pageCount === 0 && !coverEnabled}
         position={"relative"}
         overflow={"hidden"}
         _before={{

--- a/src/features/epub-maker/components/EpubToolbar.tsx
+++ b/src/features/epub-maker/components/EpubToolbar.tsx
@@ -35,7 +35,6 @@ export function EpubToolbar({
   generationProgress,
   showDownloadCompleteIcon,
   pageCount,
-  coverEnabled,
   pastedInput,
   onAddFromClipboard,
   onAddFromFiles,
@@ -55,7 +54,6 @@ export function EpubToolbar({
   generationProgress: number | null;
   showDownloadCompleteIcon: boolean;
   pageCount: number;
-  coverEnabled: boolean;
   pastedInput: string;
   onAddFromClipboard: () => Promise<void>;
   onAddFromFiles: (files: FileList | File[]) => Promise<void>;
@@ -241,7 +239,7 @@ export function EpubToolbar({
         {...actionButtonProps}
         onClick={isGenerating ? onCancelGeneration : onGenerate}
         loading={false}
-        disabled={!isGenerating && pageCount === 0 && !coverEnabled}
+        disabled={!isGenerating && pageCount === 0}
         position={"relative"}
         overflow={"hidden"}
         _before={{

--- a/src/features/epub-maker/components/PageDraftCard.tsx
+++ b/src/features/epub-maker/components/PageDraftCard.tsx
@@ -2,6 +2,7 @@ import {
   AspectRatio,
   Box,
   Button,
+  FileUpload,
   HStack,
   Icon,
   Input,
@@ -11,15 +12,19 @@ import {
 import { Tooltip } from "@components/ui/tooltip";
 import {
   LuCheck,
+  LuClipboardPaste,
   LuClock3,
   LuGripVertical,
   LuLoaderCircle,
+  LuRefreshCw,
   LuTrash2,
+  LuUpload,
 } from "react-icons/lu";
 import {
   useEffect,
   useRef,
   useState,
+  type ChangeEvent,
   type DragEvent,
   type KeyboardEvent,
   type PointerEvent as ReactPointerEvent,
@@ -38,6 +43,10 @@ export function PageDraftCard({
   page,
   chapterNumber,
   isCover,
+  hasCustomCover,
+  onReplaceCoverFromFiles,
+  onReplaceCoverFromClipboard,
+  onResetCoverToAuto,
   onRemove,
   onRename,
   onDragStart,
@@ -59,6 +68,10 @@ export function PageDraftCard({
   page: PageDraft;
   chapterNumber: number | string;
   isCover?: boolean;
+  hasCustomCover?: boolean;
+  onReplaceCoverFromFiles?: (files: FileList | File[]) => Promise<void>;
+  onReplaceCoverFromClipboard?: () => Promise<void>;
+  onResetCoverToAuto?: () => void;
   onRemove: (id: string) => void;
   onRename: (id: string, value: string) => void;
   onDragStart: (id: string, anchor: DragPreviewAnchor) => void;
@@ -79,6 +92,7 @@ export function PageDraftCard({
 }) {
   const [titleDraft, setTitleDraft] = useState(page.title);
   const cardRef = useRef<HTMLDivElement | null>(null);
+  const coverUploadInputRef = useRef<HTMLInputElement | null>(null);
   const activeTouchPointerIdRef = useRef<number | null>(null);
   const touchStartPointRef = useRef<{ x: number; y: number } | null>(null);
   const hasStartedTouchDragRef = useRef(false);
@@ -269,6 +283,14 @@ export function PageDraftCard({
   const isTitleDisabled = isInteractionDisabled || isCover;
   const canDrag = !isInteractionDisabled && !isCover;
 
+  function handleCoverUploadChange(event: ChangeEvent<HTMLInputElement>) {
+    if (!isCover || !onReplaceCoverFromFiles) return;
+    const files = event.target.files;
+    if (!files || files.length === 0) return;
+    void onReplaceCoverFromFiles(files);
+    event.target.value = "";
+  }
+
   return (
     <Box
       ref={cardRef}
@@ -361,6 +383,71 @@ export function PageDraftCard({
         cursor={"default"}
       >
         <Box position={"relative"} w={"full"} h={"full"}>
+          {isCover ? (
+            <HStack
+              position={"absolute"}
+              top={2}
+              left={2}
+              zIndex={6}
+              gap={1}
+              flexWrap={"wrap"}
+              maxW={"calc(100% - 1rem)"}
+            >
+              <FileUpload.Root maxFiles={1}>
+                <FileUpload.HiddenInput
+                  ref={coverUploadInputRef}
+                  aria-label={"Upload cover image"}
+                  accept={"image/*"}
+                  onChange={handleCoverUploadChange}
+                />
+                <Button
+                  size={"xs"}
+                  variant={"solid"}
+                  bg={"blackAlpha.600"}
+                  color={"white"}
+                  _hover={{ bg: "blackAlpha.700" }}
+                  onClick={() => coverUploadInputRef.current?.click()}
+                  disabled={isInteractionDisabled}
+                >
+                  <Icon>
+                    <LuUpload />
+                  </Icon>
+                  Upload
+                </Button>
+              </FileUpload.Root>
+
+              <Button
+                size={"xs"}
+                variant={"solid"}
+                bg={"blackAlpha.600"}
+                color={"white"}
+                _hover={{ bg: "blackAlpha.700" }}
+                onClick={() => void onReplaceCoverFromClipboard?.()}
+                disabled={isInteractionDisabled}
+              >
+                <Icon>
+                  <LuClipboardPaste />
+                </Icon>
+                Paste
+              </Button>
+
+              <Button
+                size={"xs"}
+                variant={"solid"}
+                bg={"blackAlpha.600"}
+                color={"white"}
+                _hover={{ bg: "blackAlpha.700" }}
+                onClick={onResetCoverToAuto}
+                disabled={isInteractionDisabled || !hasCustomCover}
+              >
+                <Icon>
+                  <LuRefreshCw />
+                </Icon>
+                Reset
+              </Button>
+            </HStack>
+          ) : null}
+
           {!isCover ? (
             <Tooltip content={"Drag to reorder"}>
               <Button

--- a/src/features/epub-maker/components/PageDraftCard.tsx
+++ b/src/features/epub-maker/components/PageDraftCard.tsx
@@ -14,6 +14,8 @@ import {
   LuCheck,
   LuClipboardPaste,
   LuClock3,
+  LuEye,
+  LuEyeOff,
   LuGripVertical,
   LuLoaderCircle,
   LuRefreshCw,
@@ -44,9 +46,11 @@ export function PageDraftCard({
   chapterNumber,
   isCover,
   hasCustomCover,
+  isCoverEnabled,
   onReplaceCoverFromFiles,
   onReplaceCoverFromClipboard,
   onResetCoverToAuto,
+  onToggleCoverEnabled,
   onRemove,
   onRename,
   onDragStart,
@@ -69,9 +73,11 @@ export function PageDraftCard({
   chapterNumber: number | string;
   isCover?: boolean;
   hasCustomCover?: boolean;
+  isCoverEnabled?: boolean;
   onReplaceCoverFromFiles?: (files: FileList | File[]) => Promise<void>;
   onReplaceCoverFromClipboard?: () => Promise<void>;
   onResetCoverToAuto?: () => void;
+  onToggleCoverEnabled?: () => void;
   onRemove: (id: string) => void;
   onRename: (id: string, value: string) => void;
   onDragStart: (id: string, anchor: DragPreviewAnchor) => void;
@@ -282,6 +288,7 @@ export function PageDraftCard({
   const isRemoveDisabled = isInteractionDisabled || isCover;
   const isTitleDisabled = isInteractionDisabled || isCover;
   const canDrag = !isInteractionDisabled && !isCover;
+  const isEffectiveCoverEnabled = isCoverEnabled ?? true;
 
   function handleCoverUploadChange(event: ChangeEvent<HTMLInputElement>) {
     if (!isCover || !onReplaceCoverFromFiles) return;
@@ -376,6 +383,28 @@ export function PageDraftCard({
                 >
                   <Icon>
                     <LuRefreshCw />
+                  </Icon>
+                </Button>
+              </Tooltip>
+
+              <Tooltip
+                content={
+                  isEffectiveCoverEnabled ? "Disable cover" : "Enable cover"
+                }
+              >
+                <Button
+                  size={"xs"}
+                  variant={"ghost"}
+                  onClick={() => onToggleCoverEnabled?.()}
+                  disabled={isInteractionDisabled}
+                  aria-label={
+                    isEffectiveCoverEnabled ? "Disable cover" : "Enable cover"
+                  }
+                  minW={"auto"}
+                  px={2}
+                >
+                  <Icon>
+                    {isEffectiveCoverEnabled ? <LuEyeOff /> : <LuEye />}
                   </Icon>
                 </Button>
               </Tooltip>
@@ -508,20 +537,47 @@ export function PageDraftCard({
               height: "100%",
               border: "none",
               pointerEvents: "none",
-              filter: isInteractionDisabled
-                ? "blur(1px) grayscale(0.35) saturate(0.75) brightness(0.82)"
-                : "none",
+              filter:
+                isInteractionDisabled || (isCover && !isEffectiveCoverEnabled)
+                  ? "blur(1px) grayscale(0.35) saturate(0.75) brightness(0.82)"
+                  : "none",
               transition: "filter 0.2s ease",
             }}
           />
 
-          {isInteractionDisabled ? (
+          {isInteractionDisabled || (isCover && !isEffectiveCoverEnabled) ? (
             <Box
               position={"absolute"}
               inset={0}
               pointerEvents={"none"}
               bg={"app.epub.overlay.preview"}
-            />
+            >
+              {isCover && !isEffectiveCoverEnabled ? (
+                <Box
+                  position={"absolute"}
+                  inset={0}
+                  display={"flex"}
+                  alignItems={"center"}
+                  justifyContent={"center"}
+                  px={3}
+                >
+                  <Text
+                    fontFamily={"ui"}
+                    fontSize={"xs"}
+                    fontWeight={"semibold"}
+                    color={"app.epub.fg.default"}
+                    bg={"app.epub.bg.card"}
+                    borderWidth={"1px"}
+                    borderColor={"app.epub.border.default"}
+                    rounded={"full"}
+                    px={3}
+                    py={1.5}
+                  >
+                    Cover disabled for export
+                  </Text>
+                </Box>
+              ) : null}
+            </Box>
           ) : null}
 
           {showGenerationStatus ? (

--- a/src/features/epub-maker/components/PageDraftCard.tsx
+++ b/src/features/epub-maker/components/PageDraftCard.tsx
@@ -312,21 +312,90 @@ export function PageDraftCard({
       onDrop={onDrop}
     >
       <Box borderBottomWidth={"1px"} borderColor={"app.epub.border.muted"}>
-        <InputGroup
-          startAddon={chapterNumber}
-          startAddonProps={{
-            minW: "2.25rem",
-            justifyContent: "center",
-            fontSize: "xs",
-            fontWeight: "semibold",
-            color: "app.epub.fg.muted",
-            borderLeftWidth: 0,
-            borderTopWidth: 0,
-            borderBottomWidth: "1px",
-            rounded: "none",
-          }}
-          endAddon={
-            isCover ? null : (
+        {isCover ? (
+          <HStack h={"2.25rem"} px={2} justify={"space-between"} align={"center"}>
+            <Text
+              fontFamily={"ui"}
+              fontSize={"sm"}
+              fontWeight={"medium"}
+              color={"app.epub.fg.default"}
+            >
+              Cover
+            </Text>
+
+            <HStack gap={0.5}>
+              <FileUpload.Root maxFiles={1}>
+                <FileUpload.HiddenInput
+                  ref={coverUploadInputRef}
+                  aria-label={"Upload cover image"}
+                  accept={"image/*"}
+                  onChange={handleCoverUploadChange}
+                />
+                <Tooltip content={"Upload cover"}>
+                  <Button
+                    size={"xs"}
+                    variant={"ghost"}
+                    onClick={() => coverUploadInputRef.current?.click()}
+                    disabled={isInteractionDisabled}
+                    aria-label={"Upload cover"}
+                    minW={"auto"}
+                    px={2}
+                  >
+                    <Icon>
+                      <LuUpload />
+                    </Icon>
+                  </Button>
+                </Tooltip>
+              </FileUpload.Root>
+
+              <Tooltip content={"Paste cover"}>
+                <Button
+                  size={"xs"}
+                  variant={"ghost"}
+                  onClick={() => void onReplaceCoverFromClipboard?.()}
+                  disabled={isInteractionDisabled}
+                  aria-label={"Paste cover"}
+                  minW={"auto"}
+                  px={2}
+                >
+                  <Icon>
+                    <LuClipboardPaste />
+                  </Icon>
+                </Button>
+              </Tooltip>
+
+              <Tooltip content={"Reset cover"}>
+                <Button
+                  size={"xs"}
+                  variant={"ghost"}
+                  onClick={() => onResetCoverToAuto?.()}
+                  disabled={isInteractionDisabled || !hasCustomCover}
+                  aria-label={"Reset cover"}
+                  minW={"auto"}
+                  px={2}
+                >
+                  <Icon>
+                    <LuRefreshCw />
+                  </Icon>
+                </Button>
+              </Tooltip>
+            </HStack>
+          </HStack>
+        ) : (
+          <InputGroup
+            startAddon={chapterNumber}
+            startAddonProps={{
+              minW: "2.25rem",
+              justifyContent: "center",
+              fontSize: "xs",
+              fontWeight: "semibold",
+              color: "app.epub.fg.muted",
+              borderLeftWidth: 0,
+              borderTopWidth: 0,
+              borderBottomWidth: "1px",
+              rounded: "none",
+            }}
+            endAddon={
               <Tooltip content={"Remove"}>
                 <Button
                   {...iconButtonProps}
@@ -346,35 +415,35 @@ export function PageDraftCard({
                   </Icon>
                 </Button>
               </Tooltip>
-            )
-          }
-          endAddonProps={{
-            borderRightWidth: 0,
-            borderTopWidth: 0,
-            borderBottomWidth: "1px",
-            rounded: "none",
-            p: 0,
-          }}
-        >
-          <Input
-            {...controlInputProps}
-            size={"sm"}
-            rounded={"none"}
-            borderLeftWidth={0}
-            borderRightWidth={0}
-            borderTopWidth={0}
-            borderBottomWidth={"1px"}
-            borderBottomColor={"app.epub.border.muted"}
-            bg={"app.epub.bg.card"}
-            color={"app.epub.fg.default"}
-            _placeholder={{ color: "app.epub.fg.subtle" }}
-            value={titleDraft}
-            disabled={isTitleDisabled}
-            onChange={(event) => setTitleDraft(event.target.value)}
-            onBlur={isCover ? undefined : commitRenameIfChanged}
-            onKeyDown={handleTitleKeyDown}
-          />
-        </InputGroup>
+            }
+            endAddonProps={{
+              borderRightWidth: 0,
+              borderTopWidth: 0,
+              borderBottomWidth: "1px",
+              rounded: "none",
+              p: 0,
+            }}
+          >
+            <Input
+              {...controlInputProps}
+              size={"sm"}
+              rounded={"none"}
+              borderLeftWidth={0}
+              borderRightWidth={0}
+              borderTopWidth={0}
+              borderBottomWidth={"1px"}
+              borderBottomColor={"app.epub.border.muted"}
+              bg={"app.epub.bg.card"}
+              color={"app.epub.fg.default"}
+              _placeholder={{ color: "app.epub.fg.subtle" }}
+              value={titleDraft}
+              disabled={isTitleDisabled}
+              onChange={(event) => setTitleDraft(event.target.value)}
+              onBlur={commitRenameIfChanged}
+              onKeyDown={handleTitleKeyDown}
+            />
+          </InputGroup>
+        )}
       </Box>
       <AspectRatio
         position={"relative"}
@@ -383,71 +452,6 @@ export function PageDraftCard({
         cursor={"default"}
       >
         <Box position={"relative"} w={"full"} h={"full"}>
-          {isCover ? (
-            <HStack
-              position={"absolute"}
-              top={2}
-              left={2}
-              zIndex={6}
-              gap={1}
-              flexWrap={"wrap"}
-              maxW={"calc(100% - 1rem)"}
-            >
-              <FileUpload.Root maxFiles={1}>
-                <FileUpload.HiddenInput
-                  ref={coverUploadInputRef}
-                  aria-label={"Upload cover image"}
-                  accept={"image/*"}
-                  onChange={handleCoverUploadChange}
-                />
-                <Button
-                  size={"xs"}
-                  variant={"solid"}
-                  bg={"blackAlpha.600"}
-                  color={"white"}
-                  _hover={{ bg: "blackAlpha.700" }}
-                  onClick={() => coverUploadInputRef.current?.click()}
-                  disabled={isInteractionDisabled}
-                >
-                  <Icon>
-                    <LuUpload />
-                  </Icon>
-                  Upload
-                </Button>
-              </FileUpload.Root>
-
-              <Button
-                size={"xs"}
-                variant={"solid"}
-                bg={"blackAlpha.600"}
-                color={"white"}
-                _hover={{ bg: "blackAlpha.700" }}
-                onClick={() => void onReplaceCoverFromClipboard?.()}
-                disabled={isInteractionDisabled}
-              >
-                <Icon>
-                  <LuClipboardPaste />
-                </Icon>
-                Paste
-              </Button>
-
-              <Button
-                size={"xs"}
-                variant={"solid"}
-                bg={"blackAlpha.600"}
-                color={"white"}
-                _hover={{ bg: "blackAlpha.700" }}
-                onClick={onResetCoverToAuto}
-                disabled={isInteractionDisabled || !hasCustomCover}
-              >
-                <Icon>
-                  <LuRefreshCw />
-                </Icon>
-                Reset
-              </Button>
-            </HStack>
-          ) : null}
-
           {!isCover ? (
             <Tooltip content={"Drag to reorder"}>
               <Button

--- a/src/features/epub-maker/components/PageDraftCard.tsx
+++ b/src/features/epub-maker/components/PageDraftCard.tsx
@@ -37,6 +37,7 @@ type DragPreviewAnchor = {
 export function PageDraftCard({
   page,
   chapterNumber,
+  isCover,
   onRemove,
   onRename,
   onDragStart,
@@ -56,7 +57,8 @@ export function PageDraftCard({
   generationStatus,
 }: {
   page: PageDraft;
-  chapterNumber: number;
+  chapterNumber: number | string;
+  isCover?: boolean;
   onRemove: (id: string) => void;
   onRename: (id: string, value: string) => void;
   onDragStart: (id: string, anchor: DragPreviewAnchor) => void;
@@ -263,6 +265,9 @@ export function PageDraftCard({
     fontSize: "sm",
     rounded: "xl",
   } as const;
+  const isRemoveDisabled = isInteractionDisabled || isCover;
+  const isTitleDisabled = isInteractionDisabled || isCover;
+  const canDrag = !isInteractionDisabled && !isCover;
 
   return (
     <Box
@@ -299,25 +304,27 @@ export function PageDraftCard({
             rounded: "none",
           }}
           endAddon={
-            <Tooltip content={"Remove"}>
-              <Button
-                {...iconButtonProps}
-                size={"sm"}
-                variant={"ghost"}
-                onClick={() => onRemove(page.id)}
-                aria-label={"Remove page"}
-                disabled={isInteractionDisabled}
-                px={2}
-                minW={"auto"}
-                rounded={"none"}
-                color={"app.epub.fg.danger"}
-                _hover={{ bg: "app.status.danger.bg" }}
-              >
-                <Icon>
-                  <LuTrash2 />
-                </Icon>
-              </Button>
-            </Tooltip>
+            isCover ? null : (
+              <Tooltip content={"Remove"}>
+                <Button
+                  {...iconButtonProps}
+                  size={"sm"}
+                  variant={"ghost"}
+                  onClick={() => onRemove(page.id)}
+                  aria-label={"Remove page"}
+                  disabled={isRemoveDisabled}
+                  px={2}
+                  minW={"auto"}
+                  rounded={"none"}
+                  color={"app.epub.fg.danger"}
+                  _hover={{ bg: "app.status.danger.bg" }}
+                >
+                  <Icon>
+                    <LuTrash2 />
+                  </Icon>
+                </Button>
+              </Tooltip>
+            )
           }
           endAddonProps={{
             borderRightWidth: 0,
@@ -340,9 +347,9 @@ export function PageDraftCard({
             color={"app.epub.fg.default"}
             _placeholder={{ color: "app.epub.fg.subtle" }}
             value={titleDraft}
-            disabled={isInteractionDisabled}
+            disabled={isTitleDisabled}
             onChange={(event) => setTitleDraft(event.target.value)}
-            onBlur={commitRenameIfChanged}
+            onBlur={isCover ? undefined : commitRenameIfChanged}
             onKeyDown={handleTitleKeyDown}
           />
         </InputGroup>
@@ -354,50 +361,52 @@ export function PageDraftCard({
         cursor={"default"}
       >
         <Box position={"relative"} w={"full"} h={"full"}>
-          <Tooltip content={"Drag to reorder"}>
-            <Button
-              variant={"subtle"}
-              position={"absolute"}
-              bottom={2}
-              right={2}
-              zIndex={5}
-              px={2}
-              minW={"auto"}
-              rounded={"full"}
-              cursor={isInteractionDisabled ? "not-allowed" : "grab"}
-              draggable={!isInteractionDisabled}
-              disabled={isInteractionDisabled}
-              touchAction={"none"}
-              bg={"blackAlpha.300"}
-              color={"app.epub.fg.muted"}
-              _hover={{
-                bg: "blackAlpha.400",
-                color: "app.epub.fg.default",
-              }}
-              onDragStart={(event) => {
-                if (isInteractionDisabled) return;
-                if (activeTouchPointerIdRef.current !== null) {
-                  event.preventDefault();
-                  return;
-                }
-                event.stopPropagation();
-                setCardDragPreview(event);
-              }}
-              onDragEnd={(event) => {
-                event.stopPropagation();
-                onDragEnd();
-              }}
-              onPointerDown={handleGripPointerDown}
-              onPointerMove={handleGripPointerMove}
-              onPointerUp={handleGripPointerEnd}
-              onPointerCancel={handleGripPointerCancel}
-              aria-label={"Drag page"}
-            >
-              <Icon>
-                <LuGripVertical />
-              </Icon>
-            </Button>
-          </Tooltip>
+          {!isCover ? (
+            <Tooltip content={"Drag to reorder"}>
+              <Button
+                variant={"subtle"}
+                position={"absolute"}
+                bottom={2}
+                right={2}
+                zIndex={5}
+                px={2}
+                minW={"auto"}
+                rounded={"full"}
+                cursor={canDrag ? "grab" : "not-allowed"}
+                draggable={canDrag}
+                disabled={!canDrag}
+                touchAction={"none"}
+                bg={"blackAlpha.300"}
+                color={"app.epub.fg.muted"}
+                _hover={{
+                  bg: "blackAlpha.400",
+                  color: "app.epub.fg.default",
+                }}
+                onDragStart={(event) => {
+                  if (!canDrag) return;
+                  if (activeTouchPointerIdRef.current !== null) {
+                    event.preventDefault();
+                    return;
+                  }
+                  event.stopPropagation();
+                  setCardDragPreview(event);
+                }}
+                onDragEnd={(event) => {
+                  event.stopPropagation();
+                  onDragEnd();
+                }}
+                onPointerDown={handleGripPointerDown}
+                onPointerMove={handleGripPointerMove}
+                onPointerUp={handleGripPointerEnd}
+                onPointerCancel={handleGripPointerCancel}
+                aria-label={"Drag page"}
+              >
+                <Icon>
+                  <LuGripVertical />
+                </Icon>
+              </Button>
+            </Tooltip>
+          ) : null}
 
           <iframe
             title={`preview-${page.id}`}

--- a/src/features/epub-maker/components/PageDraftCard.tsx
+++ b/src/features/epub-maker/components/PageDraftCard.tsx
@@ -289,6 +289,8 @@ export function PageDraftCard({
   const isTitleDisabled = isInteractionDisabled || isCover;
   const canDrag = !isInteractionDisabled && !isCover;
   const isEffectiveCoverEnabled = isCoverEnabled ?? true;
+  const isCoverExportDisabled = Boolean(isCover && !isEffectiveCoverEnabled);
+  const isCoverToolDisabled = isInteractionDisabled || isCoverExportDisabled;
 
   function handleCoverUploadChange(event: ChangeEvent<HTMLInputElement>) {
     if (!isCover || !onReplaceCoverFromFiles) return;
@@ -296,6 +298,15 @@ export function PageDraftCard({
     if (!files || files.length === 0) return;
     void onReplaceCoverFromFiles(files);
     event.target.value = "";
+  }
+
+  function handleCoverDisabledOverlayKeyDown(
+    event: KeyboardEvent<HTMLDivElement>,
+  ) {
+    if (!isCoverExportDisabled || isInteractionDisabled) return;
+    if (event.key !== "Enter" && event.key !== " ") return;
+    event.preventDefault();
+    onToggleCoverEnabled?.();
   }
 
   return (
@@ -343,7 +354,7 @@ export function PageDraftCard({
                     size={"xs"}
                     variant={"ghost"}
                     onClick={() => coverUploadInputRef.current?.click()}
-                    disabled={isInteractionDisabled}
+                    disabled={isCoverToolDisabled}
                     aria-label={"Upload cover"}
                     minW={"auto"}
                     px={2}
@@ -360,7 +371,7 @@ export function PageDraftCard({
                   size={"xs"}
                   variant={"ghost"}
                   onClick={() => void onReplaceCoverFromClipboard?.()}
-                  disabled={isInteractionDisabled}
+                  disabled={isCoverToolDisabled}
                   aria-label={"Paste cover"}
                   minW={"auto"}
                   px={2}
@@ -376,7 +387,7 @@ export function PageDraftCard({
                   size={"xs"}
                   variant={"ghost"}
                   onClick={() => onResetCoverToAuto?.()}
-                  disabled={isInteractionDisabled || !hasCustomCover}
+                  disabled={isCoverToolDisabled || !hasCustomCover}
                   aria-label={"Reset cover"}
                   minW={"auto"}
                   px={2}
@@ -538,21 +549,41 @@ export function PageDraftCard({
               border: "none",
               pointerEvents: "none",
               filter:
-                isInteractionDisabled || (isCover && !isEffectiveCoverEnabled)
+                isInteractionDisabled || isCoverExportDisabled
                   ? "blur(1px) grayscale(0.35) saturate(0.75) brightness(0.82)"
                   : "none",
               transition: "filter 0.2s ease",
             }}
           />
 
-          {isInteractionDisabled || (isCover && !isEffectiveCoverEnabled) ? (
+          {isInteractionDisabled || isCoverExportDisabled ? (
             <Box
               position={"absolute"}
               inset={0}
-              pointerEvents={"none"}
+              pointerEvents={
+                isCoverExportDisabled && !isInteractionDisabled ? "auto" : "none"
+              }
               bg={"app.epub.overlay.preview"}
+              cursor={
+                isCoverExportDisabled && !isInteractionDisabled
+                  ? "pointer"
+                  : "default"
+              }
+              role={
+                isCoverExportDisabled && !isInteractionDisabled
+                  ? "button"
+                  : undefined
+              }
+              tabIndex={
+                isCoverExportDisabled && !isInteractionDisabled ? 0 : undefined
+              }
+              onClick={() => {
+                if (!isCoverExportDisabled || isInteractionDisabled) return;
+                onToggleCoverEnabled?.();
+              }}
+              onKeyDown={handleCoverDisabledOverlayKeyDown}
             >
-              {isCover && !isEffectiveCoverEnabled ? (
+              {isCoverExportDisabled ? (
                 <Box
                   position={"absolute"}
                   inset={0}
@@ -561,11 +592,8 @@ export function PageDraftCard({
                   justifyContent={"center"}
                   px={3}
                 >
-                  <Text
-                    fontFamily={"ui"}
-                    fontSize={"xs"}
-                    fontWeight={"semibold"}
-                    color={"app.epub.fg.default"}
+                  <HStack
+                    gap={1.5}
                     bg={"app.epub.bg.card"}
                     borderWidth={"1px"}
                     borderColor={"app.epub.border.default"}
@@ -573,8 +601,19 @@ export function PageDraftCard({
                     px={3}
                     py={1.5}
                   >
-                    Cover disabled for export
-                  </Text>
+                    <Icon boxSize={3.5} color={"app.epub.fg.default"}>
+                      <LuEyeOff />
+                    </Icon>
+                    <Text
+                      fontFamily={"ui"}
+                      fontSize={"xs"}
+                      fontWeight={"semibold"}
+                      color={"app.epub.fg.default"}
+                      lineHeight={1.1}
+                    >
+                      Enable cover
+                    </Text>
+                  </HStack>
                 </Box>
               ) : null}
             </Box>

--- a/src/features/epub-maker/components/PageDraftGrid.tsx
+++ b/src/features/epub-maker/components/PageDraftGrid.tsx
@@ -35,6 +35,7 @@ export function PageDraftGrid({
   pages,
   coverPreviewHtml,
   hasCustomCover,
+  isCoverEnabled,
   isAdding,
   isGenerating,
   generationChapterStatusByPageId,
@@ -47,6 +48,7 @@ export function PageDraftGrid({
   onReplaceCoverFromFiles,
   onReplaceCoverFromClipboard,
   onResetCoverToAuto,
+  onToggleCoverEnabled,
   onAddFromClipboard,
   onAddFromFiles,
   pastedInput,
@@ -57,6 +59,7 @@ export function PageDraftGrid({
   pages: PageDraft[];
   coverPreviewHtml: string;
   hasCustomCover: boolean;
+  isCoverEnabled: boolean;
   isAdding: boolean;
   isGenerating: boolean;
   generationChapterStatusByPageId: Record<string, ChapterGenerationStatus>;
@@ -69,6 +72,7 @@ export function PageDraftGrid({
   onReplaceCoverFromFiles: (files: FileList | File[]) => Promise<void>;
   onReplaceCoverFromClipboard: () => Promise<void>;
   onResetCoverToAuto: () => void;
+  onToggleCoverEnabled: () => void;
   onAddFromClipboard: () => Promise<void>;
   onAddFromFiles: (files: FileList | File[]) => Promise<void>;
   pastedInput: string;
@@ -321,9 +325,11 @@ export function PageDraftGrid({
             chapterNumber={"C"}
             isCover={true}
             hasCustomCover={hasCustomCover}
+            isCoverEnabled={isCoverEnabled}
             onReplaceCoverFromFiles={onReplaceCoverFromFiles}
             onReplaceCoverFromClipboard={onReplaceCoverFromClipboard}
             onResetCoverToAuto={onResetCoverToAuto}
+            onToggleCoverEnabled={onToggleCoverEnabled}
             onRemove={onRemove}
             onRename={onRename}
             onDragStart={() => {}}

--- a/src/features/epub-maker/components/PageDraftGrid.tsx
+++ b/src/features/epub-maker/components/PageDraftGrid.tsx
@@ -35,6 +35,7 @@ export function PageDraftGrid({
   pages,
   coverEnabled,
   coverPreviewHtml,
+  hasCustomCover,
   isAdding,
   isGenerating,
   generationChapterStatusByPageId,
@@ -44,6 +45,9 @@ export function PageDraftGrid({
   onRemove,
   onRename,
   onReorder,
+  onReplaceCoverFromFiles,
+  onReplaceCoverFromClipboard,
+  onResetCoverToAuto,
   onAddFromClipboard,
   onAddFromFiles,
   pastedInput,
@@ -54,6 +58,7 @@ export function PageDraftGrid({
   pages: PageDraft[];
   coverEnabled: boolean;
   coverPreviewHtml: string;
+  hasCustomCover: boolean;
   isAdding: boolean;
   isGenerating: boolean;
   generationChapterStatusByPageId: Record<string, ChapterGenerationStatus>;
@@ -63,6 +68,9 @@ export function PageDraftGrid({
   onRemove: (id: string) => void;
   onRename: (id: string, value: string) => void;
   onReorder: (draggedId: string, targetIndex: number) => void;
+  onReplaceCoverFromFiles: (files: FileList | File[]) => Promise<void>;
+  onReplaceCoverFromClipboard: () => Promise<void>;
+  onResetCoverToAuto: () => void;
   onAddFromClipboard: () => Promise<void>;
   onAddFromFiles: (files: FileList | File[]) => Promise<void>;
   pastedInput: string;
@@ -323,6 +331,10 @@ export function PageDraftGrid({
               page={coverPage}
               chapterNumber={"C"}
               isCover={true}
+              hasCustomCover={hasCustomCover}
+              onReplaceCoverFromFiles={onReplaceCoverFromFiles}
+              onReplaceCoverFromClipboard={onReplaceCoverFromClipboard}
+              onResetCoverToAuto={onResetCoverToAuto}
               onRemove={onRemove}
               onRename={onRename}
               onDragStart={() => {}}
@@ -337,7 +349,7 @@ export function PageDraftGrid({
               }}
               onDrop={handleDrop}
               isDragging={false}
-              isDropTarget={!isInteractionDisabled && effectiveDropIndex(0) !== null}
+              isDropTarget={false}
               isInteractionDisabled={isInteractionDisabled}
               isGenerationStatusFading={isGenerationStatusFading}
               generationStatus={undefined}

--- a/src/features/epub-maker/components/PageDraftGrid.tsx
+++ b/src/features/epub-maker/components/PageDraftGrid.tsx
@@ -33,7 +33,6 @@ type DragMode = "mouse" | "touch" | null;
 
 export function PageDraftGrid({
   pages,
-  coverEnabled,
   coverPreviewHtml,
   hasCustomCover,
   isAdding,
@@ -56,7 +55,6 @@ export function PageDraftGrid({
   onAddFromFallback,
 }: {
   pages: PageDraft[];
-  coverEnabled: boolean;
   coverPreviewHtml: string;
   hasCustomCover: boolean;
   isAdding: boolean;
@@ -92,22 +90,20 @@ export function PageDraftGrid({
   const isInteractionDisabled = isGenerating;
   const isGenerationStatusVisible =
     isGenerating || Object.keys(generationChapterStatusByPageId).length > 0;
-  const coverOffset = coverEnabled ? 1 : 0;
+  const coverOffset = 1;
   const totalDisplayItemCount = pages.length + coverOffset;
   const completedPageCount = Object.values(
     generationChapterStatusByPageId,
   ).filter((status) => status === "completed").length;
-  const coverPage: PageDraft | null = coverEnabled
-    ? {
-        id: "__epub-cover__",
-        title: "Cover",
-        inputKind: "html",
-        rawContent: "",
-        baseUrl: null,
-        previewHtml: coverPreviewHtml,
-        createdAt: 0,
-      }
-    : null;
+  const coverPage: PageDraft = {
+    id: "__epub-cover__",
+    title: "Cover",
+    inputKind: "html",
+    rawContent: "",
+    baseUrl: null,
+    previewHtml: coverPreviewHtml,
+    createdAt: 0,
+  };
 
   function handleGhostUploadChange(event: ChangeEvent<HTMLInputElement>) {
     if (isInteractionDisabled) return;
@@ -125,9 +121,7 @@ export function PageDraftGrid({
       ? (() => {
           const draggedPage = pages[dragIndex];
           const remaining = pages.filter((page) => page.id !== draggedId);
-          const targetChapterIndex = coverEnabled
-            ? Math.max(0, dropIndex - 1)
-            : dropIndex;
+          const targetChapterIndex = Math.max(0, dropIndex - 1);
           const insertionIndex = Math.max(
             0,
             Math.min(targetChapterIndex, remaining.length),
@@ -146,9 +140,7 @@ export function PageDraftGrid({
       dropIndexRef.current ??
       dropIndex ??
       (dragIndex >= 0 ? dragIndex + coverOffset : 0);
-    const targetIndex = coverEnabled
-      ? Math.max(0, targetDisplayIndex - 1)
-      : targetDisplayIndex;
+    const targetIndex = Math.max(0, targetDisplayIndex - 1);
     onReorder(activeDraggedId, targetIndex);
     setDraggedId(null);
     setDropIndex(null);
@@ -251,9 +243,7 @@ export function PageDraftGrid({
       dropIndexRef.current ??
       dropIndex ??
       (dragIndex >= 0 ? dragIndex + coverOffset : 0);
-    const targetIndex = coverEnabled
-      ? Math.max(0, targetDisplayIndex - 1)
-      : targetDisplayIndex;
+    const targetIndex = Math.max(0, targetDisplayIndex - 1);
     onReorder(activeDraggedId, targetIndex);
     handleDragEnd();
   }
@@ -310,52 +300,50 @@ export function PageDraftGrid({
         gap={2}
         alignItems={"start"}
       >
-        {coverPage ? (
-          <Box
-            key={coverPage.id}
-            data-drop-index={0}
+        <Box
+          key={coverPage.id}
+          data-drop-index={0}
+          onDragOver={(event) => {
+            if (isInteractionDisabled) return;
+            event.preventDefault();
+            if (!draggedId) return;
+            setDropIndex(0);
+            dropIndexRef.current = 0;
+          }}
+          onDrop={(event) => {
+            if (isInteractionDisabled) return;
+            event.preventDefault();
+            handleDrop();
+          }}
+        >
+          <PageDraftCard
+            page={coverPage}
+            chapterNumber={"C"}
+            isCover={true}
+            hasCustomCover={hasCustomCover}
+            onReplaceCoverFromFiles={onReplaceCoverFromFiles}
+            onReplaceCoverFromClipboard={onReplaceCoverFromClipboard}
+            onResetCoverToAuto={onResetCoverToAuto}
+            onRemove={onRemove}
+            onRename={onRename}
+            onDragStart={() => {}}
+            onTouchDragStart={() => {}}
+            onTouchDragMove={() => {}}
+            onTouchDragEnd={() => {}}
+            onTouchDragCancel={() => {}}
+            onDragEnd={isInteractionDisabled ? () => {} : handleDragEnd}
             onDragOver={(event) => {
               if (isInteractionDisabled) return;
               event.preventDefault();
-              if (!draggedId) return;
-              setDropIndex(0);
-              dropIndexRef.current = 0;
             }}
-            onDrop={(event) => {
-              if (isInteractionDisabled) return;
-              event.preventDefault();
-              handleDrop();
-            }}
-          >
-            <PageDraftCard
-              page={coverPage}
-              chapterNumber={"C"}
-              isCover={true}
-              hasCustomCover={hasCustomCover}
-              onReplaceCoverFromFiles={onReplaceCoverFromFiles}
-              onReplaceCoverFromClipboard={onReplaceCoverFromClipboard}
-              onResetCoverToAuto={onResetCoverToAuto}
-              onRemove={onRemove}
-              onRename={onRename}
-              onDragStart={() => {}}
-              onTouchDragStart={() => {}}
-              onTouchDragMove={() => {}}
-              onTouchDragEnd={() => {}}
-              onTouchDragCancel={() => {}}
-              onDragEnd={isInteractionDisabled ? () => {} : handleDragEnd}
-              onDragOver={(event) => {
-                if (isInteractionDisabled) return;
-                event.preventDefault();
-              }}
-              onDrop={handleDrop}
-              isDragging={false}
-              isDropTarget={false}
-              isInteractionDisabled={isInteractionDisabled}
-              isGenerationStatusFading={isGenerationStatusFading}
-              generationStatus={undefined}
-            />
-          </Box>
-        ) : null}
+            onDrop={handleDrop}
+            isDragging={false}
+            isDropTarget={false}
+            isInteractionDisabled={isInteractionDisabled}
+            isGenerationStatusFading={isGenerationStatusFading}
+            generationStatus={undefined}
+          />
+        </Box>
 
         {previewPages.map((page, index) => {
           const displayIndex = index + coverOffset;

--- a/src/features/epub-maker/components/PageDraftGrid.tsx
+++ b/src/features/epub-maker/components/PageDraftGrid.tsx
@@ -33,6 +33,8 @@ type DragMode = "mouse" | "touch" | null;
 
 export function PageDraftGrid({
   pages,
+  coverEnabled,
+  coverPreviewHtml,
   isAdding,
   isGenerating,
   generationChapterStatusByPageId,
@@ -50,6 +52,8 @@ export function PageDraftGrid({
   onAddFromFallback,
 }: {
   pages: PageDraft[];
+  coverEnabled: boolean;
+  coverPreviewHtml: string;
   isAdding: boolean;
   isGenerating: boolean;
   generationChapterStatusByPageId: Record<string, ChapterGenerationStatus>;
@@ -80,9 +84,22 @@ export function PageDraftGrid({
   const isInteractionDisabled = isGenerating;
   const isGenerationStatusVisible =
     isGenerating || Object.keys(generationChapterStatusByPageId).length > 0;
+  const coverOffset = coverEnabled ? 1 : 0;
+  const totalDisplayItemCount = pages.length + coverOffset;
   const completedPageCount = Object.values(
     generationChapterStatusByPageId,
   ).filter((status) => status === "completed").length;
+  const coverPage: PageDraft | null = coverEnabled
+    ? {
+        id: "__epub-cover__",
+        title: "Cover",
+        inputKind: "html",
+        rawContent: "",
+        baseUrl: null,
+        previewHtml: coverPreviewHtml,
+        createdAt: 0,
+      }
+    : null;
 
   function handleGhostUploadChange(event: ChangeEvent<HTMLInputElement>) {
     if (isInteractionDisabled) return;
@@ -100,9 +117,12 @@ export function PageDraftGrid({
       ? (() => {
           const draggedPage = pages[dragIndex];
           const remaining = pages.filter((page) => page.id !== draggedId);
+          const targetChapterIndex = coverEnabled
+            ? Math.max(0, dropIndex - 1)
+            : dropIndex;
           const insertionIndex = Math.max(
             0,
-            Math.min(dropIndex, remaining.length),
+            Math.min(targetChapterIndex, remaining.length),
           );
           const next = [...remaining];
           next.splice(insertionIndex, 0, draggedPage);
@@ -114,7 +134,13 @@ export function PageDraftGrid({
     if (isInteractionDisabled) return;
     const activeDraggedId = draggedIdRef.current ?? draggedId;
     if (!activeDraggedId) return;
-    const targetIndex = dropIndexRef.current ?? dropIndex ?? dragIndex;
+    const targetDisplayIndex =
+      dropIndexRef.current ??
+      dropIndex ??
+      (dragIndex >= 0 ? dragIndex + coverOffset : 0);
+    const targetIndex = coverEnabled
+      ? Math.max(0, targetDisplayIndex - 1)
+      : targetDisplayIndex;
     onReorder(activeDraggedId, targetIndex);
     setDraggedId(null);
     setDropIndex(null);
@@ -154,8 +180,8 @@ export function PageDraftGrid({
 
     const isOverGhost = Boolean(hitTarget?.closest("[data-ghost-drop-target]"));
     if (isOverGhost) {
-      setDropIndex(pages.length);
-      dropIndexRef.current = pages.length;
+      setDropIndex(totalDisplayItemCount);
+      dropIndexRef.current = totalDisplayItemCount;
       setIsGhostDropTarget(true);
       return;
     }
@@ -179,10 +205,10 @@ export function PageDraftGrid({
     const currentIndex = pages.findIndex((page) => page.id === id);
     if (currentIndex < 0) return;
     setDraggedId(id);
-    setDropIndex(currentIndex);
+    setDropIndex(currentIndex + coverOffset);
     setDragMode("touch");
     draggedIdRef.current = id;
-    dropIndexRef.current = currentIndex;
+    dropIndexRef.current = currentIndex + coverOffset;
     setDragPreviewAnchor(anchor);
     updateDropIndexFromPoint(anchor.clientX, anchor.clientY);
   }
@@ -213,7 +239,13 @@ export function PageDraftGrid({
     if (isInteractionDisabled) return;
     const activeDraggedId = draggedIdRef.current ?? draggedId;
     if (!activeDraggedId) return;
-    const targetIndex = dropIndexRef.current ?? dropIndex ?? dragIndex;
+    const targetDisplayIndex =
+      dropIndexRef.current ??
+      dropIndex ??
+      (dragIndex >= 0 ? dragIndex + coverOffset : 0);
+    const targetIndex = coverEnabled
+      ? Math.max(0, targetDisplayIndex - 1)
+      : targetDisplayIndex;
     onReorder(activeDraggedId, targetIndex);
     handleDragEnd();
   }
@@ -270,21 +302,65 @@ export function PageDraftGrid({
         gap={2}
         alignItems={"start"}
       >
+        {coverPage ? (
+          <Box
+            key={coverPage.id}
+            data-drop-index={0}
+            onDragOver={(event) => {
+              if (isInteractionDisabled) return;
+              event.preventDefault();
+              if (!draggedId) return;
+              setDropIndex(0);
+              dropIndexRef.current = 0;
+            }}
+            onDrop={(event) => {
+              if (isInteractionDisabled) return;
+              event.preventDefault();
+              handleDrop();
+            }}
+          >
+            <PageDraftCard
+              page={coverPage}
+              chapterNumber={"C"}
+              isCover={true}
+              onRemove={onRemove}
+              onRename={onRename}
+              onDragStart={() => {}}
+              onTouchDragStart={() => {}}
+              onTouchDragMove={() => {}}
+              onTouchDragEnd={() => {}}
+              onTouchDragCancel={() => {}}
+              onDragEnd={isInteractionDisabled ? () => {} : handleDragEnd}
+              onDragOver={(event) => {
+                if (isInteractionDisabled) return;
+                event.preventDefault();
+              }}
+              onDrop={handleDrop}
+              isDragging={false}
+              isDropTarget={!isInteractionDisabled && effectiveDropIndex(0) !== null}
+              isInteractionDisabled={isInteractionDisabled}
+              isGenerationStatusFading={isGenerationStatusFading}
+              generationStatus={undefined}
+            />
+          </Box>
+        ) : null}
+
         {previewPages.map((page, index) => {
+          const displayIndex = index + coverOffset;
           const isDraggedCard = draggedId === page.id;
-          const isDropTarget = effectiveDropIndex(index) !== null;
+          const isDropTarget = effectiveDropIndex(displayIndex) !== null;
 
           return (
             <Box
               key={page.id}
-              data-drop-index={index}
+              data-drop-index={displayIndex}
               onDragOver={(event) => {
                 if (isInteractionDisabled) return;
                 event.preventDefault();
                 if (!draggedId) return;
                 if (draggedId === page.id) return;
-                setDropIndex(index);
-                dropIndexRef.current = index;
+                setDropIndex(displayIndex);
+                dropIndexRef.current = displayIndex;
               }}
               onDrop={(event) => {
                 if (isInteractionDisabled) return;
@@ -300,10 +376,10 @@ export function PageDraftGrid({
                 onDragStart={(id, anchor) => {
                   if (isInteractionDisabled) return;
                   setDraggedId(id);
-                  setDropIndex(index);
+                  setDropIndex(displayIndex);
                   setDragMode("mouse");
                   draggedIdRef.current = id;
-                  dropIndexRef.current = index;
+                  dropIndexRef.current = displayIndex;
                   setDragPreviewAnchor(anchor);
                 }}
                 onTouchDragStart={handleTouchDragStart}
@@ -358,7 +434,7 @@ export function PageDraftGrid({
             if (isInteractionDisabled) return;
             event.preventDefault();
             setIsGhostDropTarget(true);
-            dropIndexRef.current = pages.length;
+            dropIndexRef.current = totalDisplayItemCount;
           }}
           onDragLeave={(event) => {
             const nextTarget = event.relatedTarget as Node | null;

--- a/src/features/epub-maker/domain/epub-builder.ts
+++ b/src/features/epub-maker/domain/epub-builder.ts
@@ -74,6 +74,8 @@ export async function buildEpub(input: BuildEpubInput): Promise<BuildEpubResult>
   };
 
   const chapters: Chapter[] = [];
+  let coverChapter: Chapter | null = null;
+  let coverImageId: string | null = null;
   const pageCount = input.pages.length || 1;
   const progressStep = 80 / pageCount;
   const emitProgress = (
@@ -162,6 +164,73 @@ export async function buildEpub(input: BuildEpubInput): Promise<BuildEpubResult>
     emitProgress(Math.min(85, Math.round(5 + progressStep * (i + 1))), "processing_chapter", i, page.id);
   }
 
+  if (input.cover) {
+    throwIfAborted();
+    const coverTitle = input.cover.title || "Cover";
+    const sanitizedCover = sanitizeHtmlContent(
+      input.cover.rawHtml,
+      coverTitle,
+      input.sanitizePolicy,
+    );
+    const parsedCover = new DOMParser().parseFromString(
+      sanitizedCover.chapterBodyHtml,
+      "text/html",
+    );
+
+    const coverImageNodes = Array.from(parsedCover.body.querySelectorAll("img"));
+    for (const node of coverImageNodes) {
+      throwIfAborted();
+      const src = node.getAttribute("src") || "";
+      if (!src) continue;
+      const result = await registerImageAsset({
+        src,
+        baseUrl: null,
+        embedRemoteImages: input.sanitizePolicy.embedRemoteImages,
+        signal: input.signal,
+        imagesByKey,
+        nextImageNumber,
+      });
+      if (result.warning) warnings.push(result.warning);
+      if (!result.localHref && !result.absoluteSrc) {
+        node.remove();
+        continue;
+      }
+
+      if (result.localHref) {
+        const matchedImage = Array.from(imagesByKey.values()).find(
+          (image) => image.href === result.localHref,
+        );
+        if (matchedImage && !coverImageId) {
+          coverImageId = matchedImage.id;
+        }
+      }
+
+      node.setAttribute(
+        "src",
+        result.localHref ? `../${result.localHref}` : (result.absoluteSrc || src),
+      );
+    }
+
+    const coverBody = serializeBodyToXhtml(parsedCover.body);
+    const coverXhtml = `<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <title>${escapeXml(coverTitle)}</title>
+    <style>html,body{margin:0;padding:0}.cover-page{margin:0;padding:0}img{max-width:100%;height:auto;display:block}</style>
+  </head>
+  <body>
+    <div class="cover-page">${coverBody}</div>
+  </body>
+</html>`;
+
+    coverChapter = {
+      id: "cover",
+      href: "cover.xhtml",
+      title: coverTitle,
+      content: coverXhtml,
+    };
+  }
+
   const bookId =
     typeof crypto !== "undefined" && "randomUUID" in crypto
       ? crypto.randomUUID()
@@ -190,18 +259,22 @@ export async function buildEpub(input: BuildEpubInput): Promise<BuildEpubResult>
         `<item id="${chapter.id}" href="${chapter.href}" media-type="application/xhtml+xml"/>`,
     )
     .join("\n    ");
+  const manifestCoverChapterItem = coverChapter
+    ? `<item id="${coverChapter.id}" href="${coverChapter.href}" media-type="application/xhtml+xml"/>`
+    : "";
 
   const images = Array.from(imagesByKey.values());
   const manifestImageItems = images
     .map(
       (image) =>
-        `<item id="${image.id}" href="${image.href}" media-type="${escapeXml(image.mediaType)}"/>`,
+        `<item id="${image.id}" href="${image.href}" media-type="${escapeXml(image.mediaType)}"${coverImageId === image.id ? ' properties="cover-image"' : ""}/>` ,
     )
     .join("\n    ");
 
-  const spineItems = chapters
-    .map((chapter) => `<itemref idref="${chapter.id}"/>`)
-    .join("\n    ");
+  const spineItems = [
+    ...(coverChapter ? [`<itemref idref="${coverChapter.id}"/>`] : []),
+    ...chapters.map((chapter) => `<itemref idref="${chapter.id}"/>`),
+  ].join("\n    ");
 
   const contentOpf = `<?xml version="1.0" encoding="UTF-8"?>
 <package xmlns="http://www.idpf.org/2007/opf" unique-identifier="book-id" version="3.0">
@@ -210,11 +283,13 @@ export async function buildEpub(input: BuildEpubInput): Promise<BuildEpubResult>
     <dc:title>${escapeXml(input.bookTitle)}</dc:title>
     ${input.bookAuthor ? `<dc:creator>${escapeXml(input.bookAuthor)}</dc:creator>` : ""}
     <dc:language>en</dc:language>
+    ${coverImageId ? `<meta name="cover" content="${escapeXml(coverImageId)}"/>` : ""}
     <meta property="dcterms:modified">${new Date().toISOString().replace(/\.\d{3}Z$/, "Z")}</meta>
   </metadata>
   <manifest>
     <item id="nav" href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"/>
     <item id="ncx" href="toc.ncx" media-type="application/x-dtbncx+xml"/>
+    ${manifestCoverChapterItem}
     ${manifestChapterItems}
     ${manifestImageItems}
   </manifest>
@@ -278,6 +353,10 @@ export async function buildEpub(input: BuildEpubInput): Promise<BuildEpubResult>
   oebps.file("nav.xhtml", navXhtml);
   oebps.file("toc.ncx", tocNcx);
 
+  if (coverChapter) {
+    oebps.file(coverChapter.href, coverChapter.content);
+  }
+
   for (const chapter of chapters) {
     oebps.file(chapter.href, chapter.content);
   }
@@ -303,6 +382,7 @@ export async function buildEpub(input: BuildEpubInput): Promise<BuildEpubResult>
     summary: {
       fileName: input.downloadFileName || "book.epub",
       chapterCount: chapters.length,
+      coverIncluded: Boolean(coverChapter),
       embeddedImageCount: images.length,
       externalImageCount: warnings.filter((warning) => warning.code === "FETCH_IMAGE_FAILED").length,
       durationMs: Date.now() - startedAt,

--- a/src/features/epub-maker/domain/html-sanitizer.ts
+++ b/src/features/epub-maker/domain/html-sanitizer.ts
@@ -18,6 +18,10 @@ function extractSpacedText(root: Element | null | undefined): string {
   return parts.join(" ");
 }
 
+interface PreviewDocumentOptions {
+  variant?: "default" | "cover";
+}
+
 export function inferTitleFromHtml(value: string, fallback: string): string {
   try {
     const parser = new DOMParser();
@@ -39,8 +43,17 @@ export function inferTitleFromHtml(value: string, fallback: string): string {
   }
 }
 
-function createPreviewDocument(body: string): string {
-  return `<!doctype html><html><head><meta charset="utf-8" /><meta name="color-scheme" content="light" /><style>:root{color-scheme:light}html,body{margin:0;padding:0;overflow:hidden;background:#fff;color:#111}body{font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;font-size:12px;line-height:1.35;padding:10px}img{max-width:100%;height:auto}h1,h2,h3,h4,h5,h6{margin:8px 0 4px}p,li,blockquote,pre{margin:4px 0}a{color:#2563eb;text-decoration:none}*{scrollbar-width:none}*::-webkit-scrollbar{width:0;height:0}</style></head><body>${body}</body></html>`;
+function createPreviewDocument(
+  body: string,
+  options?: PreviewDocumentOptions,
+): string {
+  const variant = options?.variant ?? "default";
+  const coverStyles =
+    variant === "cover"
+      ? "body{padding:0;font-size:0;line-height:0;height:100%}body>*{margin:0}figure{margin:0;width:100%;height:100%}img{display:block;width:100%;height:100%;object-fit:cover}"
+      : "body{font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;font-size:12px;line-height:1.35;padding:10px}img{max-width:100%;height:auto}h1,h2,h3,h4,h5,h6{margin:8px 0 4px}p,li,blockquote,pre{margin:4px 0}a{color:#2563eb;text-decoration:none}";
+
+  return `<!doctype html><html><head><meta charset="utf-8" /><meta name="color-scheme" content="light" /><style>:root{color-scheme:light}html,body{margin:0;padding:0;overflow:hidden;background:#fff;color:#111;height:100%}${coverStyles}*{scrollbar-width:none}*::-webkit-scrollbar{width:0;height:0}</style></head><body>${body}</body></html>`;
 }
 
 function appendSanitizedNode(
@@ -118,6 +131,7 @@ export function sanitizeHtmlContent(
   html: string,
   fallbackPageTitle: string,
   policy: SanitizationPolicy,
+  previewOptions?: PreviewDocumentOptions,
 ): SanitizedHtmlResult {
   const parser = new DOMParser();
   const parsed = parser.parseFromString(html, "text/html");
@@ -160,7 +174,7 @@ export function sanitizeHtmlContent(
     title,
     baseUrl,
     chapterBodyHtml: container.innerHTML,
-    previewHtml: createPreviewDocument(previewContainer.innerHTML),
+    previewHtml: createPreviewDocument(previewContainer.innerHTML, previewOptions),
     stats,
   };
 }

--- a/src/features/epub-maker/hooks/useEpubMaker.ts
+++ b/src/features/epub-maker/hooks/useEpubMaker.ts
@@ -261,7 +261,6 @@ export type UseEpubMakerReturn = EpubMakerState & {
   toggleFileNameMode: () => void;
   setEmbedRemoteImages: (value: boolean) => void;
   setAllowExternalLinks: (value: boolean) => void;
-  setCoverEnabled: (value: boolean) => void;
   replaceCoverFromFiles: (files: FileList | File[]) => Promise<void>;
   replaceCoverFromClipboard: () => Promise<void>;
   resetCoverToAuto: () => void;
@@ -274,7 +273,6 @@ export function useEpubMaker(): UseEpubMakerReturn {
     future: [],
   });
   const [isAdding, setIsAdding] = useState(false);
-  const [coverEnabled, setCoverEnabledState] = useState(true);
   const [customCoverHtml, setCustomCoverHtml] = useState<string | null>(null);
   const [isGenerating, setIsGenerating] = useState(false);
   const [isCancellingGeneration, setIsCancellingGeneration] = useState(false);
@@ -1080,9 +1078,9 @@ export function useEpubMaker(): UseEpubMakerReturn {
     const abortController = new AbortController();
     generationAbortControllerRef.current = abortController;
 
-    if (pages.length === 0 && !coverEnabled) {
+    if (pages.length === 0) {
       const message =
-        "Add at least one page or enable cover before generating EPUB.";
+        "Add at least one page before generating EPUB.";
       setErrors([message]);
       notify("warning", "No pages added", message);
       setIsGenerating(false);
@@ -1111,7 +1109,7 @@ export function useEpubMaker(): UseEpubMakerReturn {
         bookAuthor: normalizedBookAuthor,
         downloadFileName: effectiveFileName,
         pages,
-        cover: coverEnabled ? coverDraft : undefined,
+        cover: coverDraft,
         sanitizePolicy,
         signal: abortController.signal,
         onProgress: (update: BuildEpubProgressUpdate) => {
@@ -1188,7 +1186,6 @@ export function useEpubMaker(): UseEpubMakerReturn {
 
   return {
     pages,
-    coverEnabled,
     coverMode: coverDraft.mode,
     coverPreviewHtml: coverDraft.previewHtml,
     hasCustomCover,
@@ -1263,10 +1260,6 @@ export function useEpubMaker(): UseEpubMakerReturn {
         ...prev,
         sanitizeOptions: { ...prev.sanitizeOptions, allowExternalLinks: value },
       })),
-    setCoverEnabled: (value: boolean) => {
-      setCoverEnabledState(value);
-      setSummary("");
-    },
     replaceCoverFromFiles,
     replaceCoverFromClipboard,
     resetCoverToAuto,

--- a/src/features/epub-maker/hooks/useEpubMaker.ts
+++ b/src/features/epub-maker/hooks/useEpubMaker.ts
@@ -45,30 +45,35 @@ const PAGE_HISTORY_LIMIT = 100;
 type PageFlashKind = "added" | "duplicate";
 type PageFlashEntry = { kind: PageFlashKind; token: number };
 
-interface PageHistoryState {
-  past: PageDraft[][];
-  present: PageDraft[];
-  future: PageDraft[][];
+type DraftSnapshot = {
+  pages: PageDraft[];
+  customCoverHtml: string | null;
+};
+
+interface DraftHistoryState {
+  past: DraftSnapshot[];
+  present: DraftSnapshot;
+  future: DraftSnapshot[];
 }
 
-type PageHistoryAction =
-  | { type: "commit"; updater: (previousPages: PageDraft[]) => PageDraft[] }
+type DraftHistoryAction =
+  | { type: "commit"; updater: (previousDraft: DraftSnapshot) => DraftSnapshot }
   | { type: "undo" }
   | { type: "redo" };
 
-function pageHistoryReducer(
-  state: PageHistoryState,
-  action: PageHistoryAction,
-): PageHistoryState {
+function draftHistoryReducer(
+  state: DraftHistoryState,
+  action: DraftHistoryAction,
+): DraftHistoryState {
   if (action.type === "undo") {
     if (state.past.length === 0) {
       return state;
     }
 
-    const previousPages = state.past[state.past.length - 1];
+    const previousDraft = state.past[state.past.length - 1];
     return {
       past: state.past.slice(0, -1),
-      present: previousPages,
+      present: previousDraft,
       future: [...state.future.slice(-(PAGE_HISTORY_LIMIT - 1)), state.present],
     };
   }
@@ -78,22 +83,22 @@ function pageHistoryReducer(
       return state;
     }
 
-    const nextPages = state.future[state.future.length - 1];
+    const nextDraft = state.future[state.future.length - 1];
     return {
       past: [...state.past.slice(-(PAGE_HISTORY_LIMIT - 1)), state.present],
-      present: nextPages,
+      present: nextDraft,
       future: state.future.slice(0, -1),
     };
   }
 
-  const nextPages = action.updater(state.present);
-  if (nextPages === state.present) {
+  const nextDraft = action.updater(state.present);
+  if (nextDraft === state.present) {
     return state;
   }
 
   return {
     past: [...state.past.slice(-(PAGE_HISTORY_LIMIT - 1)), state.present],
-    present: nextPages,
+    present: nextDraft,
     future: [],
   };
 }
@@ -267,13 +272,15 @@ export type UseEpubMakerReturn = EpubMakerState & {
 };
 
 export function useEpubMaker(): UseEpubMakerReturn {
-  const [pageHistory, dispatchPageHistory] = useReducer(pageHistoryReducer, {
+  const [draftHistory, dispatchDraftHistory] = useReducer(draftHistoryReducer, {
     past: [],
-    present: [],
+    present: {
+      pages: [],
+      customCoverHtml: null,
+    },
     future: [],
   });
   const [isAdding, setIsAdding] = useState(false);
-  const [customCoverHtml, setCustomCoverHtml] = useState<string | null>(null);
   const [isGenerating, setIsGenerating] = useState(false);
   const [isCancellingGeneration, setIsCancellingGeneration] = useState(false);
   const [generationProgress, setGenerationProgress] = useState<number | null>(
@@ -308,19 +315,36 @@ export function useEpubMaker(): UseEpubMakerReturn {
   const pageFlashClearTimerRef = useRef<number | null>(null);
   const flashSequenceRef = useRef(0);
   const generationAbortControllerRef = useRef<AbortController | null>(null);
-  const pages = pageHistory.present;
+  const pages = draftHistory.present.pages;
+  const customCoverHtml = draftHistory.present.customCoverHtml;
 
-  const canUndo = pageHistory.past.length > 0;
-  const canRedo = pageHistory.future.length > 0;
+  const canUndo = draftHistory.past.length > 0;
+  const canRedo = draftHistory.future.length > 0;
 
-  const commitPageChange = useCallback(
-    (updater: (previousPages: PageDraft[]) => PageDraft[]) => {
-      dispatchPageHistory({ type: "commit", updater });
+  const commitDraftChange = useCallback(
+    (updater: (previousDraft: DraftSnapshot) => DraftSnapshot) => {
+      dispatchDraftHistory({ type: "commit", updater });
       setGenerationChapterStatusByPageId({});
       setActiveGenerationPageId(null);
       setIsGenerationStatusFading(false);
     },
     [],
+  );
+
+  const commitPageChange = useCallback(
+    (updater: (previousPages: PageDraft[]) => PageDraft[]) => {
+      commitDraftChange((previousDraft) => {
+        const nextPages = updater(previousDraft.pages);
+        if (nextPages === previousDraft.pages) {
+          return previousDraft;
+        }
+        return {
+          ...previousDraft,
+          pages: nextPages,
+        };
+      });
+    },
+    [commitDraftChange],
   );
 
   useEffect(() => {
@@ -395,12 +419,12 @@ export function useEpubMaker(): UseEpubMakerReturn {
 
   const undoPages = useCallback(() => {
     if (isGenerating) return;
-    dispatchPageHistory({ type: "undo" });
+    dispatchDraftHistory({ type: "undo" });
   }, [isGenerating]);
 
   const redoPages = useCallback(() => {
     if (isGenerating) return;
-    dispatchPageHistory({ type: "redo" });
+    dispatchDraftHistory({ type: "redo" });
   }, [isGenerating]);
 
   function dismissNotification(id: string) {
@@ -1003,7 +1027,15 @@ export function useEpubMaker(): UseEpubMakerReturn {
     setIsAdding(true);
     try {
       const coverHtml = await clipboardImageBlobToHtml(imageFile);
-      setCustomCoverHtml(coverHtml);
+      commitDraftChange((previousDraft) => {
+        if (previousDraft.customCoverHtml === coverHtml) {
+          return previousDraft;
+        }
+        return {
+          ...previousDraft,
+          customCoverHtml: coverHtml,
+        };
+      });
       setSummary("");
       notify("success", "Cover updated", `Custom cover set from “${imageFile.name}”.`);
     } catch (error) {
@@ -1022,7 +1054,15 @@ export function useEpubMaker(): UseEpubMakerReturn {
     try {
       const imageBlob = await readClipboardImageBlob();
       const coverHtml = await clipboardImageBlobToHtml(imageBlob);
-      setCustomCoverHtml(coverHtml);
+      commitDraftChange((previousDraft) => {
+        if (previousDraft.customCoverHtml === coverHtml) {
+          return previousDraft;
+        }
+        return {
+          ...previousDraft,
+          customCoverHtml: coverHtml,
+        };
+      });
       setSummary("");
       notify("success", "Cover updated", "Custom cover set from clipboard image.");
     } catch (error) {
@@ -1049,7 +1089,18 @@ export function useEpubMaker(): UseEpubMakerReturn {
   }
 
   function resetCoverToAuto() {
-    setCustomCoverHtml(null);
+    if (isGenerating) return;
+    if (!hasCustomCover) return;
+
+    commitDraftChange((previousDraft) => {
+      if (previousDraft.customCoverHtml === null) {
+        return previousDraft;
+      }
+      return {
+        ...previousDraft,
+        customCoverHtml: null,
+      };
+    });
     setSummary("");
     notify("info", "Cover reset", "Switched back to the auto-generated cover.");
   }

--- a/src/features/epub-maker/hooks/useEpubMaker.ts
+++ b/src/features/epub-maker/hooks/useEpubMaker.ts
@@ -16,13 +16,17 @@ import {
 } from "../constants";
 import type {
   BuildEpubProgressUpdate,
+  CoverDraft,
+  CoverMode,
   EpubMakerState,
   GenerationWarning,
   PageId,
   PageDraft,
+  SanitizationPolicy,
 } from "../types";
 import { buildAutoEpubFileName, buildEpubFileName } from "../utils/file-name";
 import { createPageDraftFromInput } from "../domain/page-draft";
+import { sanitizeHtmlContent } from "../domain/html-sanitizer";
 import {
   clipboardImageBlobToHtml,
   readClipboardPageInput,
@@ -117,6 +121,111 @@ function isMarkdownFile(file: File): boolean {
   );
 }
 
+function escapeXmlText(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function wrapTextLines(
+  value: string,
+  maxCharsPerLine: number,
+  maxLines: number,
+): string[] {
+  const words = value.trim().split(/\s+/).filter(Boolean);
+  if (words.length === 0) return [];
+
+  const lines: string[] = [];
+  let currentLine = "";
+
+  const pushCurrentLine = () => {
+    if (!currentLine) return;
+    lines.push(currentLine);
+    currentLine = "";
+  };
+
+  for (const word of words) {
+    const candidate = currentLine ? `${currentLine} ${word}` : word;
+    if (candidate.length <= maxCharsPerLine) {
+      currentLine = candidate;
+      continue;
+    }
+
+    if (!currentLine && word.length > maxCharsPerLine) {
+      lines.push(word.slice(0, maxCharsPerLine));
+      const remainder = word.slice(maxCharsPerLine);
+      currentLine = remainder;
+      if (lines.length >= maxLines) break;
+      continue;
+    }
+
+    pushCurrentLine();
+    currentLine = word;
+    if (lines.length >= maxLines) break;
+  }
+
+  pushCurrentLine();
+
+  if (lines.length > maxLines) {
+    lines.length = maxLines;
+  }
+
+  if (words.join(" ").length > lines.join(" ").length) {
+    const lastLineIndex = lines.length - 1;
+    if (lastLineIndex >= 0) {
+      lines[lastLineIndex] = `${lines[lastLineIndex].replace(/[\s.]+$/g, "")}…`;
+    }
+  }
+
+  return lines;
+}
+
+function createAutoCoverSvgDataUrl(title: string, author: string): string {
+  const titleLines = wrapTextLines(title || DEFAULT_BOOK_TITLE, 18, 4);
+  const authorLines = wrapTextLines(author || "", 24, 2);
+
+  const titleStartY = 700 - Math.max(0, titleLines.length - 1) * 58;
+  const titleTspans = titleLines
+    .map(
+      (line, index) =>
+        `<tspan x="600" y="${titleStartY + index * 116}">${escapeXmlText(line)}</tspan>`,
+    )
+    .join("");
+  const authorStartY = titleStartY + titleLines.length * 120 + 60;
+  const authorTspans = authorLines
+    .map(
+      (line, index) =>
+        `<tspan x="600" y="${authorStartY + index * 72}">${escapeXmlText(line)}</tspan>`,
+    )
+    .join("");
+
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="1800" viewBox="0 0 1200 1800" role="img" aria-label="Book cover"><defs><linearGradient id="coverGradient" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#173753"/><stop offset="100%" stop-color="#3a6ea5"/></linearGradient></defs><rect width="1200" height="1800" fill="url(#coverGradient)"/><rect x="76" y="76" width="1048" height="1648" rx="40" fill="none" stroke="rgba(255,255,255,0.34)" stroke-width="4"/><text fill="#f8fbff" font-family="Inter, Segoe UI, Roboto, Arial, sans-serif" font-size="92" font-weight="700" text-anchor="middle">${titleTspans}</text>${authorTspans ? `<text fill="#d8e7f6" font-family="Inter, Segoe UI, Roboto, Arial, sans-serif" font-size="54" font-weight="500" text-anchor="middle">${authorTspans}</text>` : ""}</svg>`;
+
+  return `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`;
+}
+
+function createAutoCoverHtml(title: string, author: string): string {
+  const coverSrc = createAutoCoverSvgDataUrl(title, author);
+  return `<figure><img src="${coverSrc}" alt="Cover for ${escapeXmlText(title)}" /></figure>`;
+}
+
+function buildCoverDraft(
+  rawHtml: string,
+  mode: CoverMode,
+  sanitizePolicy: SanitizationPolicy,
+): CoverDraft {
+  const sanitized = sanitizeHtmlContent(rawHtml, "Cover", sanitizePolicy);
+  return {
+    mode,
+    title: "Cover",
+    rawHtml,
+    previewHtml: sanitized.previewHtml,
+  };
+}
+
 export type UseEpubMakerReturn = EpubMakerState & {
   normalizedBookTitle: string;
   normalizedBookAuthor: string;
@@ -148,6 +257,9 @@ export type UseEpubMakerReturn = EpubMakerState & {
   toggleFileNameMode: () => void;
   setEmbedRemoteImages: (value: boolean) => void;
   setAllowExternalLinks: (value: boolean) => void;
+  setCoverEnabled: (value: boolean) => void;
+  replaceCoverFromFiles: (files: FileList | File[]) => Promise<void>;
+  resetCoverToAuto: () => void;
 };
 
 export function useEpubMaker(): UseEpubMakerReturn {
@@ -157,6 +269,8 @@ export function useEpubMaker(): UseEpubMakerReturn {
     future: [],
   });
   const [isAdding, setIsAdding] = useState(false);
+  const [coverEnabled, setCoverEnabledState] = useState(true);
+  const [customCoverHtml, setCustomCoverHtml] = useState<string | null>(null);
   const [isGenerating, setIsGenerating] = useState(false);
   const [isCancellingGeneration, setIsCancellingGeneration] = useState(false);
   const [generationProgress, setGenerationProgress] = useState<number | null>(
@@ -374,6 +488,11 @@ export function useEpubMaker(): UseEpubMakerReturn {
         )
       : autoEpubFileName;
 
+  const autoCoverRawHtml = useMemo(
+    () => createAutoCoverHtml(normalizedBookTitle, normalizedBookAuthor),
+    [normalizedBookTitle, normalizedBookAuthor],
+  );
+
   const sanitizePolicy = useMemo(() => {
     const policy = createDefaultSanitizationPolicy();
     policy.embedRemoteImages = prefs.sanitizeOptions.embedRemoteImages;
@@ -383,6 +502,14 @@ export function useEpubMaker(): UseEpubMakerReturn {
     prefs.sanitizeOptions.embedRemoteImages,
     prefs.sanitizeOptions.allowExternalLinks,
   ]);
+
+  const coverDraft = useMemo(() => {
+    if (customCoverHtml) {
+      return buildCoverDraft(customCoverHtml, "custom", sanitizePolicy);
+    }
+    return buildCoverDraft(autoCoverRawHtml, "auto", sanitizePolicy);
+  }, [autoCoverRawHtml, customCoverHtml, sanitizePolicy]);
+  const hasCustomCover = coverDraft.mode === "custom";
 
   useEffect(() => {
     setPrefs(readEpubMakerPrefs());
@@ -848,6 +975,49 @@ export function useEpubMaker(): UseEpubMakerReturn {
     });
   }
 
+  async function replaceCoverFromFiles(files: FileList | File[]) {
+    if (isGenerating) return;
+
+    const uploadedFiles = Array.from(files);
+    if (uploadedFiles.length === 0) {
+      notify("warning", "No cover file selected", "Choose an image file to set as cover.");
+      return;
+    }
+
+    const imageFile = uploadedFiles.find((file) =>
+      file.type.toLowerCase().startsWith("image/"),
+    );
+
+    if (!imageFile) {
+      notify(
+        "warning",
+        "Unsupported cover format",
+        "Only image files can be used as a custom cover.",
+      );
+      return;
+    }
+
+    setIsAdding(true);
+    try {
+      const coverHtml = await clipboardImageBlobToHtml(imageFile);
+      setCustomCoverHtml(coverHtml);
+      setSummary("");
+      notify("success", "Cover updated", `Custom cover set from “${imageFile.name}”.`);
+    } catch (error) {
+      const message = `Could not set custom cover: ${String(error)}`;
+      setErrors([message]);
+      notify("error", "Couldn’t update cover", message);
+    } finally {
+      setIsAdding(false);
+    }
+  }
+
+  function resetCoverToAuto() {
+    setCustomCoverHtml(null);
+    setSummary("");
+    notify("info", "Cover reset", "Switched back to the auto-generated cover.");
+  }
+
   async function generateEpub() {
     if (isGenerating) return;
     if (generationStatusFadeTimerRef.current) {
@@ -872,9 +1042,9 @@ export function useEpubMaker(): UseEpubMakerReturn {
     const abortController = new AbortController();
     generationAbortControllerRef.current = abortController;
 
-    if (pages.length === 0) {
+    if (pages.length === 0 && !coverEnabled) {
       const message =
-        "Add at least one page from clipboard before generating EPUB.";
+        "Add at least one page or enable cover before generating EPUB.";
       setErrors([message]);
       notify("warning", "No pages added", message);
       setIsGenerating(false);
@@ -903,6 +1073,7 @@ export function useEpubMaker(): UseEpubMakerReturn {
         bookAuthor: normalizedBookAuthor,
         downloadFileName: effectiveFileName,
         pages,
+        cover: coverEnabled ? coverDraft : undefined,
         sanitizePolicy,
         signal: abortController.signal,
         onProgress: (update: BuildEpubProgressUpdate) => {
@@ -931,7 +1102,7 @@ export function useEpubMaker(): UseEpubMakerReturn {
       showDownloadCompleteIconTemporarily();
       setWarnings(result.warnings);
       setSummary(
-        `Generated and downloaded “${effectiveFileName}” with ${result.summary.chapterCount} page(s), ${result.summary.embeddedImageCount} embedded image(s), and ${result.summary.externalImageCount} external image reference(s).`,
+        `Generated and downloaded “${effectiveFileName}” with ${result.summary.chapterCount} page(s)${result.summary.coverIncluded ? " and a cover" : ""}, ${result.summary.embeddedImageCount} embedded image(s), and ${result.summary.externalImageCount} external image reference(s).`,
       );
       notify(
         "success",
@@ -979,6 +1150,10 @@ export function useEpubMaker(): UseEpubMakerReturn {
 
   return {
     pages,
+    coverEnabled,
+    coverMode: coverDraft.mode,
+    coverPreviewHtml: coverDraft.previewHtml,
+    hasCustomCover,
     isAdding,
     isGenerating,
     isCancellingGeneration,
@@ -1050,5 +1225,11 @@ export function useEpubMaker(): UseEpubMakerReturn {
         ...prev,
         sanitizeOptions: { ...prev.sanitizeOptions, allowExternalLinks: value },
       })),
+    setCoverEnabled: (value: boolean) => {
+      setCoverEnabledState(value);
+      setSummary("");
+    },
+    replaceCoverFromFiles,
+    resetCoverToAuto,
   };
 }

--- a/src/features/epub-maker/hooks/useEpubMaker.ts
+++ b/src/features/epub-maker/hooks/useEpubMaker.ts
@@ -48,6 +48,7 @@ type PageFlashEntry = { kind: PageFlashKind; token: number };
 type DraftSnapshot = {
   pages: PageDraft[];
   customCoverHtml: string | null;
+  coverEnabled: boolean;
 };
 
 interface DraftHistoryState {
@@ -269,6 +270,7 @@ export type UseEpubMakerReturn = EpubMakerState & {
   replaceCoverFromFiles: (files: FileList | File[]) => Promise<void>;
   replaceCoverFromClipboard: () => Promise<void>;
   resetCoverToAuto: () => void;
+  toggleCoverEnabled: () => void;
 };
 
 export function useEpubMaker(): UseEpubMakerReturn {
@@ -277,6 +279,7 @@ export function useEpubMaker(): UseEpubMakerReturn {
     present: {
       pages: [],
       customCoverHtml: null,
+      coverEnabled: true,
     },
     future: [],
   });
@@ -317,6 +320,7 @@ export function useEpubMaker(): UseEpubMakerReturn {
   const generationAbortControllerRef = useRef<AbortController | null>(null);
   const pages = draftHistory.present.pages;
   const customCoverHtml = draftHistory.present.customCoverHtml;
+  const coverEnabled = draftHistory.present.coverEnabled;
 
   const canUndo = draftHistory.past.length > 0;
   const canRedo = draftHistory.future.length > 0;
@@ -536,7 +540,7 @@ export function useEpubMaker(): UseEpubMakerReturn {
     }
     return buildCoverDraft(autoCoverRawHtml, "auto", sanitizePolicy);
   }, [autoCoverRawHtml, customCoverHtml, sanitizePolicy]);
-  const hasCustomCover = coverDraft.mode === "custom";
+  const hasCustomCover = customCoverHtml !== null;
 
   useEffect(() => {
     setPrefs(readEpubMakerPrefs());
@@ -1105,6 +1109,29 @@ export function useEpubMaker(): UseEpubMakerReturn {
     notify("info", "Cover reset", "Switched back to the auto-generated cover.");
   }
 
+  function toggleCoverEnabled() {
+    if (isGenerating) return;
+
+    const nextCoverEnabled = !coverEnabled;
+    commitDraftChange((previousDraft) => {
+      if (previousDraft.coverEnabled === nextCoverEnabled) {
+        return previousDraft;
+      }
+      return {
+        ...previousDraft,
+        coverEnabled: nextCoverEnabled,
+      };
+    });
+    setSummary("");
+    notify(
+      "info",
+      nextCoverEnabled ? "Cover enabled" : "Cover disabled",
+      nextCoverEnabled
+        ? "Cover will be included in generated EPUB files."
+        : "Cover preview is kept, but cover is excluded from EPUB generation.",
+    );
+  }
+
   async function generateEpub() {
     if (isGenerating) return;
     if (generationStatusFadeTimerRef.current) {
@@ -1160,7 +1187,7 @@ export function useEpubMaker(): UseEpubMakerReturn {
         bookAuthor: normalizedBookAuthor,
         downloadFileName: effectiveFileName,
         pages,
-        cover: coverDraft,
+        cover: coverEnabled ? coverDraft : undefined,
         sanitizePolicy,
         signal: abortController.signal,
         onProgress: (update: BuildEpubProgressUpdate) => {
@@ -1238,6 +1265,7 @@ export function useEpubMaker(): UseEpubMakerReturn {
   return {
     pages,
     coverMode: coverDraft.mode,
+    isCoverEnabled: coverEnabled,
     coverPreviewHtml: coverDraft.previewHtml,
     hasCustomCover,
     isAdding,
@@ -1314,5 +1342,6 @@ export function useEpubMaker(): UseEpubMakerReturn {
     replaceCoverFromFiles,
     replaceCoverFromClipboard,
     resetCoverToAuto,
+    toggleCoverEnabled,
   };
 }

--- a/src/features/epub-maker/hooks/useEpubMaker.ts
+++ b/src/features/epub-maker/hooks/useEpubMaker.ts
@@ -29,6 +29,7 @@ import { createPageDraftFromInput } from "../domain/page-draft";
 import { sanitizeHtmlContent } from "../domain/html-sanitizer";
 import {
   clipboardImageBlobToHtml,
+  readClipboardImageBlob,
   readClipboardPageInput,
 } from "../services/clipboard";
 import {
@@ -208,8 +209,9 @@ function createAutoCoverSvgDataUrl(title: string, author: string): string {
 }
 
 function createAutoCoverHtml(title: string, author: string): string {
+  const safeTitle = title || DEFAULT_BOOK_TITLE;
   const coverSrc = createAutoCoverSvgDataUrl(title, author);
-  return `<figure><img src="${coverSrc}" alt="Cover for ${escapeXmlText(title)}" /></figure>`;
+  return `<figure><img src="${coverSrc}" alt="Cover for ${escapeXmlText(safeTitle)}" /></figure>`;
 }
 
 function buildCoverDraft(
@@ -217,7 +219,9 @@ function buildCoverDraft(
   mode: CoverMode,
   sanitizePolicy: SanitizationPolicy,
 ): CoverDraft {
-  const sanitized = sanitizeHtmlContent(rawHtml, "Cover", sanitizePolicy);
+  const sanitized = sanitizeHtmlContent(rawHtml, "Cover", sanitizePolicy, {
+    variant: "cover",
+  });
   return {
     mode,
     title: "Cover",
@@ -259,6 +263,7 @@ export type UseEpubMakerReturn = EpubMakerState & {
   setAllowExternalLinks: (value: boolean) => void;
   setCoverEnabled: (value: boolean) => void;
   replaceCoverFromFiles: (files: FileList | File[]) => Promise<void>;
+  replaceCoverFromClipboard: () => Promise<void>;
   resetCoverToAuto: () => void;
 };
 
@@ -1012,6 +1017,39 @@ export function useEpubMaker(): UseEpubMakerReturn {
     }
   }
 
+  async function replaceCoverFromClipboard() {
+    if (isGenerating) return;
+
+    setIsAdding(true);
+    try {
+      const imageBlob = await readClipboardImageBlob();
+      const coverHtml = await clipboardImageBlobToHtml(imageBlob);
+      setCustomCoverHtml(coverHtml);
+      setSummary("");
+      notify("success", "Cover updated", "Custom cover set from clipboard image.");
+    } catch (error) {
+      const rawMessage = String(error);
+      const normalizedMessage = rawMessage.toLowerCase();
+      if (
+        normalizedMessage.includes("clipboard") ||
+        normalizedMessage.includes("not supported")
+      ) {
+        notify(
+          "warning",
+          "No clipboard image found",
+          "Copy an image first, then use Paste cover.",
+        );
+        return;
+      }
+
+      const message = `Could not paste cover image: ${rawMessage}`;
+      setErrors([message]);
+      notify("error", "Couldn’t update cover", message);
+    } finally {
+      setIsAdding(false);
+    }
+  }
+
   function resetCoverToAuto() {
     setCustomCoverHtml(null);
     setSummary("");
@@ -1230,6 +1268,7 @@ export function useEpubMaker(): UseEpubMakerReturn {
       setSummary("");
     },
     replaceCoverFromFiles,
+    replaceCoverFromClipboard,
     resetCoverToAuto,
   };
 }

--- a/src/features/epub-maker/services/clipboard.ts
+++ b/src/features/epub-maker/services/clipboard.ts
@@ -19,6 +19,28 @@ async function blobToDataUrl(blob: Blob): Promise<string> {
   return `data:${mediaType};base64,${base64}`;
 }
 
+export async function readClipboardImageBlob(): Promise<Blob> {
+  if (typeof navigator === "undefined" || !navigator.clipboard) {
+    throw new Error("Clipboard API unavailable");
+  }
+
+  if (!("read" in navigator.clipboard)) {
+    throw new Error("Clipboard image read is not supported in this browser.");
+  }
+
+  const items = await navigator.clipboard.read();
+  for (const item of items) {
+    const imageType = imageTypeFromClipboardItemTypes(item.types);
+    if (!imageType) continue;
+    const imageBlob = await item.getType(imageType);
+    if (imageBlob.size > 0) {
+      return imageBlob;
+    }
+  }
+
+  throw new Error("Clipboard does not contain an image.");
+}
+
 export async function clipboardImageBlobToHtml(blob: Blob): Promise<string> {
   const dataUrl = await blobToDataUrl(blob);
   return `<figure><img src="${dataUrl}" alt="Pasted image" /></figure>`;

--- a/src/features/epub-maker/types.ts
+++ b/src/features/epub-maker/types.ts
@@ -118,6 +118,7 @@ export interface EpubMakerPrefs {
 export interface EpubMakerState {
   pages: PageDraft[];
   coverMode: CoverMode;
+  isCoverEnabled: boolean;
   coverPreviewHtml: string;
   hasCustomCover: boolean;
   isAdding: boolean;

--- a/src/features/epub-maker/types.ts
+++ b/src/features/epub-maker/types.ts
@@ -117,7 +117,6 @@ export interface EpubMakerPrefs {
 
 export interface EpubMakerState {
   pages: PageDraft[];
-  coverEnabled: boolean;
   coverMode: CoverMode;
   coverPreviewHtml: string;
   hasCustomCover: boolean;

--- a/src/features/epub-maker/types.ts
+++ b/src/features/epub-maker/types.ts
@@ -4,6 +4,7 @@ export type PageInputKind = "html" | "text";
 export type FileNameMode = "auto" | "manual";
 export type PageId = string;
 export type ChapterGenerationStatus = "pending" | "processing" | "completed";
+export type CoverMode = "auto" | "custom";
 
 export interface PageDraft {
   id: PageId;
@@ -50,6 +51,7 @@ export interface GenerationWarning {
 export interface GenerationSummary {
   fileName: string;
   chapterCount: number;
+  coverIncluded: boolean;
   embeddedImageCount: number;
   externalImageCount: number;
   durationMs: number;
@@ -70,11 +72,19 @@ export interface SanitizationPolicy {
   maxPreviewNodes: number;
 }
 
+export interface CoverDraft {
+  mode: CoverMode;
+  title: string;
+  rawHtml: string;
+  previewHtml: string;
+}
+
 export interface BuildEpubInput {
   bookTitle: string;
   bookAuthor?: string;
   downloadFileName?: string;
   pages: PageDraft[];
+  cover?: CoverDraft;
   sanitizePolicy: SanitizationPolicy;
   signal?: AbortSignal;
   onProgress?: (update: BuildEpubProgressUpdate) => void;
@@ -107,6 +117,10 @@ export interface EpubMakerPrefs {
 
 export interface EpubMakerState {
   pages: PageDraft[];
+  coverEnabled: boolean;
+  coverMode: CoverMode;
+  coverPreviewHtml: string;
+  hasCustomCover: boolean;
   isAdding: boolean;
   isGenerating: boolean;
   generationProgress: number | null;


### PR DESCRIPTION
## Summary\n- add and refine EPUB Maker cover workflow (pinned cover, disable/enable cover export, and undo/redo integration)\n- polish disabled-cover UX and cover action controls in the draft grid\n- replace local shortcut token rendering with shared  in EPUB Maker help dialog\n\nCloses #80