### PR TITLE
Finalize EPUB Maker defaults and remove beta status

### DIFF
--- a/src/features/epub-maker/components/EpubMetadataForm.tsx
+++ b/src/features/epub-maker/components/EpubMetadataForm.tsx
@@ -10,6 +10,7 @@ import {
 import { Switch } from "@components/ui/switch";
 import { Tooltip } from "@components/ui/tooltip";
 import { LuCircleHelp, LuSettings2 } from "react-icons/lu";
+import { DEFAULT_BOOK_TITLE } from "../constants";
 import type { EpubMakerState } from "../types";
 
 export function EpubMetadataForm({
@@ -65,7 +66,7 @@ export function EpubMetadataForm({
           </Text>
           <Input
             {...controlInputProps}
-            placeholder={"EPUB Maker"}
+            placeholder={DEFAULT_BOOK_TITLE}
             bg={"app.epub.bg.card"}
             color={"app.epub.fg.default"}
             borderColor={"app.epub.border.default"}

--- a/src/features/epub-maker/components/EpubMetadataForm.tsx
+++ b/src/features/epub-maker/components/EpubMetadataForm.tsx
@@ -81,7 +81,7 @@ export function EpubMetadataForm({
           </Text>
           <Input
             {...controlInputProps}
-            placeholder={"Your name"}
+            placeholder={"Name"}
             bg={"app.epub.bg.card"}
             color={"app.epub.fg.default"}
             borderColor={"app.epub.border.default"}

--- a/src/features/epub-maker/components/EpubMetadataForm.tsx
+++ b/src/features/epub-maker/components/EpubMetadataForm.tsx
@@ -65,7 +65,7 @@ export function EpubMetadataForm({
           </Text>
           <Input
             {...controlInputProps}
-            placeholder={"EPUB Maker Pages"}
+            placeholder={"EPUB Maker"}
             bg={"app.epub.bg.card"}
             color={"app.epub.fg.default"}
             borderColor={"app.epub.border.default"}

--- a/src/features/epub-maker/components/PageDraftCard.tsx
+++ b/src/features/epub-maker/components/PageDraftCard.tsx
@@ -65,6 +65,14 @@ import {
   clipboardImageBlobToHtml,
   readClipboardImageBlob,
 } from "../services/clipboard";
+import {
+  DEFAULT_COVER_BASE_BACKGROUND_ID,
+  DEFAULT_COVER_HIDE_TEXT,
+  DEFAULT_COVER_SIZE_PRESET_ID,
+  DEFAULT_COVER_TEXT_COLOR_MODE,
+  DEFAULT_COVER_TEXT_POSITION,
+  DEFAULT_COVER_TEXT_SCALE_PERCENT,
+} from "../constants";
 import { useCoverSettingsSession } from "../hooks/useCoverSettingsSession";
 import {
   BufferedCoverPreview,
@@ -104,8 +112,10 @@ const COVER_SIZE_LABEL_MODE: CoverSizeLabelMode = "side";
 const SHOW_SIZE_DESCRIPTIONS = true;
 const COVER_GRID_HOVER_BG = "app.status.info.bg" as const;
 const COVER_GRID_SELECTED_BORDER_COLOR = "app.epub.button.primary.border" as const;
-const COVER_AUTO_DEFAULT_BACKGROUND_ID: BaseCoverBackgroundId = "monochrome";
-const COVER_AUTO_DEFAULT_SIZE_PRESET_ID: CoverSizePresetId = "ratio_1_1_6";
+const COVER_AUTO_DEFAULT_BACKGROUND_ID: BaseCoverBackgroundId =
+  DEFAULT_COVER_BASE_BACKGROUND_ID;
+const COVER_AUTO_DEFAULT_SIZE_PRESET_ID: CoverSizePresetId =
+  DEFAULT_COVER_SIZE_PRESET_ID;
 
 const dropdownGridItemInteractionProps = {
   p: 1,
@@ -445,16 +455,17 @@ export function PageDraftCard({
     const fallbackBackgroundId =
       selectedCoverBackgroundId && isBaseBackgroundId(selectedCoverBackgroundId)
         ? selectedCoverBackgroundId
-        : "monochrome";
+        : COVER_AUTO_DEFAULT_BACKGROUND_ID;
     return {
       coverEnabled: isCoverEnabled ?? true,
       customCoverHtml: hasCustomCover ? (customCoverHtml ?? null) : null,
       coverBaseBackgroundId: fallbackBackgroundId,
       coverSizePresetId: selectedCoverSizePresetId ?? COVER_AUTO_DEFAULT_SIZE_PRESET_ID,
-      coverTextScalePercent: coverTextScalePercent ?? 100,
-      coverTextPosition: coverTextPosition ?? "style_1",
-      coverTextColorMode: coverTextColorMode ?? "adaptive",
-      hideCoverText: hideCoverText ?? false,
+      coverTextScalePercent:
+        coverTextScalePercent ?? DEFAULT_COVER_TEXT_SCALE_PERCENT,
+      coverTextPosition: coverTextPosition ?? DEFAULT_COVER_TEXT_POSITION,
+      coverTextColorMode: coverTextColorMode ?? DEFAULT_COVER_TEXT_COLOR_MODE,
+      hideCoverText: hideCoverText ?? DEFAULT_COVER_HIDE_TEXT,
     };
   }, [
     selectedCoverBackgroundId,
@@ -1075,10 +1086,11 @@ export function PageDraftCard({
                                 customCoverHtml: null,
                                 coverBaseBackgroundId: COVER_AUTO_DEFAULT_BACKGROUND_ID,
                                 coverSizePresetId: COVER_AUTO_DEFAULT_SIZE_PRESET_ID,
-                                coverTextPosition: "style_1",
-                                coverTextScalePercent: 100,
-                                coverTextColorMode: "adaptive",
-                                hideCoverText: false,
+                                coverTextPosition: DEFAULT_COVER_TEXT_POSITION,
+                                coverTextScalePercent:
+                                  DEFAULT_COVER_TEXT_SCALE_PERCENT,
+                                coverTextColorMode: DEFAULT_COVER_TEXT_COLOR_MODE,
+                                hideCoverText: DEFAULT_COVER_HIDE_TEXT,
                               }))
                             }
                             disabled={isInteractionDisabled}

--- a/src/features/epub-maker/components/PageDraftCard.tsx
+++ b/src/features/epub-maker/components/PageDraftCard.tsx
@@ -104,7 +104,7 @@ const COVER_SIZE_LABEL_MODE: CoverSizeLabelMode = "side";
 const SHOW_SIZE_DESCRIPTIONS = true;
 const COVER_GRID_HOVER_BG = "app.status.info.bg" as const;
 const COVER_GRID_SELECTED_BORDER_COLOR = "app.epub.button.primary.border" as const;
-const COVER_AUTO_DEFAULT_BACKGROUND_ID: BaseCoverBackgroundId = "aurora";
+const COVER_AUTO_DEFAULT_BACKGROUND_ID: BaseCoverBackgroundId = "monochrome";
 const COVER_AUTO_DEFAULT_SIZE_PRESET_ID: CoverSizePresetId = "ratio_1_1_6";
 
 const dropdownGridItemInteractionProps = {
@@ -445,7 +445,7 @@ export function PageDraftCard({
     const fallbackBackgroundId =
       selectedCoverBackgroundId && isBaseBackgroundId(selectedCoverBackgroundId)
         ? selectedCoverBackgroundId
-        : "aurora";
+        : "monochrome";
     return {
       coverEnabled: isCoverEnabled ?? true,
       customCoverHtml: hasCustomCover ? (customCoverHtml ?? null) : null,

--- a/src/features/epub-maker/constants.ts
+++ b/src/features/epub-maker/constants.ts
@@ -9,7 +9,7 @@ export const EPUB_MAKER_STORAGE_FIELDS = {
   fileNameMode: "file-name-mode",
   generationOptions: "generation-options",
 } as const;
-export const DEFAULT_BOOK_TITLE = "EPUB Maker Pages";
+export const DEFAULT_BOOK_TITLE = "EPUB Maker";
 
 const DROP_TAGS = [
   "script",

--- a/src/features/epub-maker/constants.ts
+++ b/src/features/epub-maker/constants.ts
@@ -1,4 +1,12 @@
-import { SanitizationPolicy } from "./types";
+import type {
+  BaseCoverBackgroundId,
+  CoverSettingsState,
+  CoverTextColorMode,
+  CoverTextPosition,
+  CoverSizePresetId,
+  EpubMakerPrefs,
+  SanitizationPolicy,
+} from "./types";
 
 export const EPUB_MAKER_TOOL_ID = "epub-maker";
 export const EPUB_MAKER_STORAGE_FIELDS = {
@@ -10,6 +18,38 @@ export const EPUB_MAKER_STORAGE_FIELDS = {
   generationOptions: "generation-options",
 } as const;
 export const DEFAULT_BOOK_TITLE = "EPUB Maker";
+export const DEFAULT_COVER_BASE_BACKGROUND_ID: BaseCoverBackgroundId =
+  "monochrome";
+export const DEFAULT_COVER_SIZE_PRESET_ID: CoverSizePresetId = "ratio_1_1_6";
+export const DEFAULT_COVER_TEXT_SCALE_PERCENT = 100;
+export const DEFAULT_COVER_TEXT_POSITION: CoverTextPosition = "style_1";
+export const DEFAULT_COVER_TEXT_COLOR_MODE: CoverTextColorMode = "adaptive";
+export const DEFAULT_COVER_HIDE_TEXT = false;
+
+export function createDefaultCoverPrefs(): EpubMakerPrefs["cover"] {
+  return {
+    backgroundId: DEFAULT_COVER_BASE_BACKGROUND_ID,
+    baseBackgroundId: DEFAULT_COVER_BASE_BACKGROUND_ID,
+    sizePresetId: DEFAULT_COVER_SIZE_PRESET_ID,
+    textScalePercent: DEFAULT_COVER_TEXT_SCALE_PERCENT,
+    textPosition: DEFAULT_COVER_TEXT_POSITION,
+    textColorMode: DEFAULT_COVER_TEXT_COLOR_MODE,
+    hideText: DEFAULT_COVER_HIDE_TEXT,
+  };
+}
+
+export function createDefaultCoverSettings(): CoverSettingsState {
+  return {
+    coverEnabled: true,
+    customCoverHtml: null,
+    coverBaseBackgroundId: DEFAULT_COVER_BASE_BACKGROUND_ID,
+    coverSizePresetId: DEFAULT_COVER_SIZE_PRESET_ID,
+    coverTextPosition: DEFAULT_COVER_TEXT_POSITION,
+    coverTextScalePercent: DEFAULT_COVER_TEXT_SCALE_PERCENT,
+    coverTextColorMode: DEFAULT_COVER_TEXT_COLOR_MODE,
+    hideCoverText: DEFAULT_COVER_HIDE_TEXT,
+  };
+}
 
 const DROP_TAGS = [
   "script",

--- a/src/features/epub-maker/hooks/useEpubMaker.ts
+++ b/src/features/epub-maker/hooks/useEpubMaker.ts
@@ -1118,7 +1118,7 @@ export function useEpubMaker(): UseEpubMakerReturn {
     applyCoverSettings({
       coverEnabled: true,
       customCoverHtml: null,
-      coverBaseBackgroundId: "aurora",
+      coverBaseBackgroundId: "monochrome",
       coverSizePresetId: "ratio_1_1_6",
       coverTextPosition: "style_1",
       coverTextScalePercent: 100,

--- a/src/features/epub-maker/hooks/useEpubMaker.ts
+++ b/src/features/epub-maker/hooks/useEpubMaker.ts
@@ -11,6 +11,7 @@ import {
 } from "react";
 import { LuChevronDown, LuFilePlus } from "react-icons/lu";
 import {
+  createDefaultCoverSettings,
   createDefaultSanitizationPolicy,
   DEFAULT_BOOK_TITLE,
 } from "../constants";
@@ -1115,16 +1116,7 @@ export function useEpubMaker(): UseEpubMakerReturn {
   function resetCoverToAuto() {
     if (isGenerating) return;
 
-    applyCoverSettings({
-      coverEnabled: true,
-      customCoverHtml: null,
-      coverBaseBackgroundId: "monochrome",
-      coverSizePresetId: "ratio_1_1_6",
-      coverTextPosition: "style_1",
-      coverTextScalePercent: 100,
-      coverTextColorMode: "adaptive",
-      hideCoverText: false,
-    });
+    applyCoverSettings(createDefaultCoverSettings());
   }
 
   function toggleCoverEnabled() {

--- a/src/features/epub-maker/services/prefs-storage.ts
+++ b/src/features/epub-maker/services/prefs-storage.ts
@@ -1,5 +1,6 @@
 import {
   DEFAULT_BOOK_TITLE,
+  createDefaultCoverPrefs,
   EPUB_MAKER_STORAGE_FIELDS,
   EPUB_MAKER_TOOL_ID,
 } from "../constants";
@@ -16,15 +17,7 @@ import { buildToolStorageKey } from "@utils/storage";
 const defaultPrefs: EpubMakerPrefs = {
   title: "",
   author: "",
-  cover: {
-    backgroundId: "monochrome",
-    baseBackgroundId: "monochrome",
-    sizePresetId: "ratio_1_1_6",
-    textScalePercent: 100,
-    textPosition: "style_1",
-    textColorMode: "adaptive",
-    hideText: false,
-  },
+  cover: createDefaultCoverPrefs(),
   manualFileName: "",
   fileNameMode: "auto",
   generationOptions: {

--- a/src/features/tools/data/tools-registry.ts
+++ b/src/features/tools/data/tools-registry.ts
@@ -25,7 +25,7 @@ const TOOL_SEEDS: ToolSeed[] = [
     tagline: "Convert pasted HTML, text, or images into clean EPUB files",
     description:
       "Paste HTML pages, plain text, or images, reorder chapters, set metadata, and generate a downloadable EPUB.",
-    status: "beta",
+    status: "stable",
     tags: [{ id: "epub", label: "EPUB" }],
     path: "/tools/epub-maker/",
     sortOrder: 10,


### PR DESCRIPTION
## Summary
- change default EPUB title to "EPUB Maker" and use shared constant for title placeholder
- switch reset and initialization defaults to monochrome cover theme
- centralize EPUB cover defaults in shared constants to avoid duplicated literals
- change author placeholder to "Name"
- mark EPUB Maker tool status as stable (remove beta badge)

## Notes
- includes only EPUB Maker related updates and tool status registry change