### PR TITLE
Fix tool hydration and functional test races

### DIFF
--- a/src/app/(home)/about/Client.tsx
+++ b/src/app/(home)/about/Client.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { Heading1, SectionText } from "@components/core/Texts";
+import { homepageTabs } from "app/route-info";
+import { Box, Spacer, VStack } from "@chakra-ui/react";
+import { useProseStyles } from "@components/article/proseStyles";
+
+function Main({ html }: { html: string }) {
+  const proseStyles = useProseStyles();
+
+  return (
+    <Box m={[4, 6]} letterSpacing={"wide"} lineHeight={"tall"}>
+      <VStack align={"stretch"} gap={5}>
+        <SectionText>{homepageTabs.about.name}</SectionText>
+        <Spacer h={4} />
+        <Heading1>
+          It&apos;s me,{" "}
+          <Box
+            as="span"
+            className="handwritten handwritten-squiggle squiggle-pink"
+            fontFamily={"handwritten"}
+            fontSize={"1.25em"}
+            fontWeight={"black"}
+          >
+            Aman
+          </Box>
+          !
+        </Heading1>
+        <Box
+          className="prose-content"
+          css={proseStyles}
+          dangerouslySetInnerHTML={{ __html: html }}
+        />
+      </VStack>
+    </Box>
+  );
+}
+
+export default function AboutClient({ html }: { html: string }) {
+  return (
+    <VStack align="stretch" gap={8}>
+      <Main html={html} />
+    </VStack>
+  );
+}

--- a/src/app/(home)/about/page.tsx
+++ b/src/app/(home)/about/page.tsx
@@ -1,55 +1,11 @@
-"use client";
-
-import { Heading1, SectionText } from "@components/core/Texts";
-import { homepageTabs } from "app/route-info";
-import { Box, Spacer, VStack } from "@chakra-ui/react";
 import AboutData from "data/about";
 import { renderMarkdownToHtml } from "@utils/markdown";
-import { useProseStyles } from "@components/article/proseStyles";
-import { useEffect, useState } from "react";
+import AboutClient from "./Client";
 
-function Main() {
-  const [html, setHtml] = useState("");
+export default async function About() {
+  const html = await renderMarkdownToHtml(AboutData.markdown, {
+    allowDangerousHtml: true,
+  });
 
-  useEffect(() => {
-    renderMarkdownToHtml(AboutData.markdown, {
-      allowDangerousHtml: true,
-    }).then(setHtml);
-  }, []);
-
-  const proseStyles = useProseStyles();
-  return (
-    <Box m={[4, 6]} letterSpacing={"wide"} lineHeight={"tall"}>
-      <VStack align={"stretch"} gap={5}>
-        <SectionText>{homepageTabs.about.name}</SectionText>
-        <Spacer h={4} />
-        <Heading1>
-          It&apos;s me,{" "}
-          <Box
-            as="span"
-            className="handwritten handwritten-squiggle squiggle-pink"
-            fontFamily={"handwritten"}
-            fontSize={"1.25em"}
-            fontWeight={"black"}
-          >
-            Aman
-          </Box>
-          !
-        </Heading1>
-        <Box
-          className="prose-content"
-          css={proseStyles}
-          dangerouslySetInnerHTML={{ __html: html }}
-        />
-      </VStack>
-    </Box>
-  );
-}
-
-export default function About() {
-  return (
-    <VStack align="stretch" gap={8}>
-      <Main />
-    </VStack>
-  );
+  return <AboutClient html={html} />;
 }

--- a/src/app/(home)/blogs/BlogsClient.tsx
+++ b/src/app/(home)/blogs/BlogsClient.tsx
@@ -66,7 +66,7 @@ function BlogsListElement({ blogs }: { blogs: BlogMeta[] }) {
 }
 
 function Blogs({ blogs }: { blogs: BlogMeta[] }) {
-  const [, forceEmptyStates] = useFeatureFlag(
+  const [forceEmptyStates] = useFeatureFlag(
     FeatureFlagsData.featuresIds.FORCE_EMPTY_STATES,
   );
 
@@ -78,13 +78,11 @@ function Blogs({ blogs }: { blogs: BlogMeta[] }) {
 }
 
 export default function BlogsClient({ blogs }: { blogs: BlogMeta[] }) {
-  const [isLoading, isBlogsFeatureEnabled] = useFeatureFlag(
+  const [isBlogsFeatureEnabled] = useFeatureFlag(
     FeatureFlagsData.featuresIds.BLOGS,
   );
 
-  if (isLoading) {
-    return null;
-  } else if (!isBlogsFeatureEnabled) {
+  if (!isBlogsFeatureEnabled) {
     return notFound();
   }
 

--- a/src/app/(home)/blogs/[id]/Client.tsx
+++ b/src/app/(home)/blogs/[id]/Client.tsx
@@ -91,10 +91,9 @@ function ExternalLinksBlock({ links }: { links?: ExternalLink[] }) {
 }
 
 export default function Client({ html, blog }: { html: string; blog: Blog }) {
-  const [isLoading, isBlogsFeatureEnabled] = useFeatureFlag(
+  const [isBlogsFeatureEnabled] = useFeatureFlag(
     FeatureFlagsData.featuresIds.BLOGS,
   );
-  if (isLoading) return null;
   if (!isBlogsFeatureEnabled) return null;
   if (!blog) return null;
 

--- a/src/app/(home)/page.tsx
+++ b/src/app/(home)/page.tsx
@@ -42,7 +42,7 @@ function Main() {
 }
 
 function Projects() {
-  const [, forceEmptyStates] = useFeatureFlag(
+  const [forceEmptyStates] = useFeatureFlag(
     FeatureFlagsData.featuresIds.FORCE_EMPTY_STATES,
   );
 
@@ -113,7 +113,7 @@ function getTimeStringFromExp(exp: WorkExperience) {
 }
 
 function WorkExperience() {
-  const [, forceEmptyStates] = useFeatureFlag(
+  const [forceEmptyStates] = useFeatureFlag(
     FeatureFlagsData.featuresIds.FORCE_EMPTY_STATES,
   );
 

--- a/src/app/(home)/projects/ProjectsClient.tsx
+++ b/src/app/(home)/projects/ProjectsClient.tsx
@@ -83,7 +83,7 @@ function Projects({
   projects: ProjectMeta[];
   projectIdsWithDetails: string[];
 }) {
-  const [, forceEmptyStates] = useFeatureFlag(
+  const [forceEmptyStates] = useFeatureFlag(
     FeatureFlagsData.featuresIds.FORCE_EMPTY_STATES,
   );
 

--- a/src/app/features/page.tsx
+++ b/src/app/features/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { EmptyState, VStack, Spacer, Box, Icon, Skeleton } from "@chakra-ui/react";
+import { EmptyState, VStack, Spacer, Box, Icon } from "@chakra-ui/react";
 import { Heading1, SectionText, SubtitleText } from "@components/core/Texts";
 import { TileList, TitleDescriptionToggleTile } from "@components/core/Tiles";
 import HighlightedSection from "@components/page/common/HighlightedSection";
@@ -42,13 +42,9 @@ function NoFeatureFlagsElement() {
 }
 
 function FeatureFlagTile({ featureFlag }: { featureFlag: FeatureFlagEntry }) {
-  const [isLoading, featureFlagValue, setFeatureFlag] = useFeatureFlag(
-    featureFlag.id,
-  );
+  const [featureFlagValue, setFeatureFlag] = useFeatureFlag(featureFlag.id);
 
-  return isLoading ? (
-    <Skeleton w={"full"} h={"24"} rounded={"2xl"} />
-  ) : (
+  return (
     <TitleDescriptionToggleTile
       title={featureFlag.name}
       description={featureFlag.desc}
@@ -71,7 +67,7 @@ function FeatureFlagsListElement() {
 }
 
 function FeatureFlags() {
-  return FeatureFlagsData.flags.length != 0
+  return FeatureFlagsData.flags.length !== 0
     ? FeatureFlagsListElement()
     : NoFeatureFlagsElement();
 }

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -2,7 +2,7 @@
 
 import { ThemeProvider } from "next-themes";
 import { system } from "@config/chakra";
-import { ChakraProvider, ClientOnly } from "@chakra-ui/react";
+import { ChakraProvider } from "@chakra-ui/react";
 import { Global } from "@emotion/react";
 import { useProseStyles } from "@components/article/proseStyles";
 import { getAppGlobalStyles } from "./globalStyles";
@@ -13,9 +13,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
   return (
     <ChakraProvider value={system}>
       <Global styles={globalStyles} />
-      <ClientOnly>
-        <ThemeProvider attribute="class">{children}</ThemeProvider>
-      </ClientOnly>
+      <ThemeProvider attribute="class">{children}</ThemeProvider>
     </ChakraProvider>
   );
 }

--- a/src/app/tools/calendar-drill/page.tsx
+++ b/src/app/tools/calendar-drill/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { ClientOnly } from "@chakra-ui/react";
 import { CalendarDrillPage } from "features/calendar-drill";
 import { ToolDetailsSection, getToolById } from "features/tools";
 
@@ -9,7 +10,9 @@ export default function CalendarDrillToolPage() {
   return (
     <>
       {tool ? <ToolDetailsSection tool={tool} /> : null}
-      <CalendarDrillPage />
+      <ClientOnly>
+        <CalendarDrillPage />
+      </ClientOnly>
     </>
   );
 }

--- a/src/app/tools/epub-maker/page.tsx
+++ b/src/app/tools/epub-maker/page.tsx
@@ -1,17 +1,25 @@
 "use client";
 
+import { ClientOnly } from "@chakra-ui/react";
 import { EpubMakerPageView, useEpubMaker } from "features/epub-maker";
 import { getToolById, ToolDetailsSection } from "features/tools";
 import { EpubHelpButton } from "features/epub-maker/components/EpubHelpButton";
 
-export default function EpubMakerPage() {
+function EpubMakerClientEditor() {
   const epubMaker = useEpubMaker();
+
+  return <EpubMakerPageView {...epubMaker} />;
+}
+
+export default function EpubMakerPage() {
   const tool = getToolById("epub-maker");
 
   return (
     <>
       {tool ? <ToolDetailsSection tool={tool} titleAction={<EpubHelpButton />} /> : null}
-      <EpubMakerPageView {...epubMaker} />
+      <ClientOnly>
+        <EpubMakerClientEditor />
+      </ClientOnly>
     </>
   );
 }

--- a/src/components/page/common/Header.tsx
+++ b/src/components/page/common/Header.tsx
@@ -94,7 +94,7 @@ export default function Header() {
   const currentPathname = usePathname() ?? "";
   const [isMobileMenuOpen, setMobileMenuOpen] = useState(false);
   const mobileMenuContainerRef = useRef<HTMLDivElement>(null);
-  const [, isBlogsFeatureEnabled, ,] = useFeatureFlag(
+  const [isBlogsFeatureEnabled] = useFeatureFlag(
     FeatureFlagsData.featuresIds.BLOGS,
   );
 

--- a/src/features/calendar-drill/components/CalendarDrillPage.tsx
+++ b/src/features/calendar-drill/components/CalendarDrillPage.tsx
@@ -34,7 +34,6 @@ import {
   LuSettings2,
 } from "react-icons/lu";
 import {
-  createDefaultPracticeSettings,
   readCalendarDrillSettings,
   writeCalendarDrillSettings,
 } from "../services/settings-storage";
@@ -133,14 +132,14 @@ function isKeyboardEventFromInteractiveElement(
 }
 
 export function CalendarDrillPage() {
-  const [settingsDraft, setSettingsDraft] = useState<PracticeSettings>(
-    createDefaultPracticeSettings,
-  );
+  const [initialSettings] = useState(() => readCalendarDrillSettings());
+  const [settingsDraft, setSettingsDraft] =
+    useState<PracticeSettings>(initialSettings);
   const [isAdvancedSettingsOpen, setIsAdvancedSettingsOpen] = useState(false);
   const monthDragModeRef = useRef<MonthDragMode>(null);
   const didHandleMonthPointerRef = useRef(false);
 
-  const [settings, setSettings] = useState<PracticeSettings>(settingsDraft);
+  const [settings, setSettings] = useState<PracticeSettings>(initialSettings);
   const [isSettingsLoaded, setIsSettingsLoaded] = useState(false);
 
   const [status, setStatus] = useState<SessionStatus>("idle");
@@ -223,9 +222,6 @@ export function CalendarDrillPage() {
   }, [question]);
 
   useEffect(() => {
-    const savedSettings = readCalendarDrillSettings();
-    setSettingsDraft(savedSettings);
-    setSettings(savedSettings);
     setIsSettingsLoaded(true);
   }, []);
 

--- a/src/features/tools/components/ToolsDirectoryPage.tsx
+++ b/src/features/tools/components/ToolsDirectoryPage.tsx
@@ -106,7 +106,7 @@ function Main({
 export function ToolsDirectoryPage() {
   const content = getToolsPageContent();
   const tools = getAllTools();
-  const [, forceEmptyStates] = useFeatureFlag(
+  const [forceEmptyStates] = useFeatureFlag(
     FeatureFlagsData.featuresIds.FORCE_EMPTY_STATES,
   );
   const [filters, setFilters] = useState<ToolFiltersState>(defaultFilters);

--- a/src/utils/features/index.ts
+++ b/src/utils/features/index.ts
@@ -1,104 +1,66 @@
 import FeatureFlagsData from "data/features";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { buildFeatureFlagStorageKey } from "../storage";
 
-class FeatureFlagsManager {
-  constructor() {}
-
-  private getLocalStorageKeyFromFeatureFlagId(featureFlagId: string) {
-    return buildFeatureFlagStorageKey(featureFlagId);
+function getFeatureById(featureFlagId: string) {
+  const featureFlag = FeatureFlagsData.flags.find(
+    (value) => value.id === featureFlagId,
+  );
+  if (!featureFlag) {
+    throw new Error(`Feature flag with id ${featureFlagId} not found`);
   }
 
-  getFeatureById(featureFlagId: string) {
-    const featureFlag = FeatureFlagsData.flags.find(
-      (value, _, __) => value.id == featureFlagId,
+  return featureFlag;
+}
+
+function parseStoredFeatureFlagValue(
+  value: string | null,
+  defaultValue: boolean,
+): boolean {
+  if (value === null) return defaultValue;
+  if (value.toLowerCase() === "true") return true;
+  if (value.toLowerCase() === "false") return false;
+  return defaultValue;
+}
+
+function readFeatureFlagValue(featureFlagId: string): boolean {
+  const featureFlag = getFeatureById(featureFlagId);
+  const storageKey = buildFeatureFlagStorageKey(featureFlagId);
+
+  try {
+    return parseStoredFeatureFlagValue(
+      window.localStorage.getItem(storageKey),
+      featureFlag.defaultValue,
     );
-    if (featureFlag) {
-      return featureFlag;
-    } else {
-      throw new Error(`Feature flag with id ${featureFlagId} not found`);
-    }
-  }
-
-  getFeatureFlagValue(featureFlagId: string) {
-    const featureFlag = this.getFeatureById(featureFlagId);
-    const ffValueString = localStorage.getItem(
-      this.getLocalStorageKeyFromFeatureFlagId(featureFlagId),
-    );
-    if (ffValueString === null) {
-      return featureFlag.defaultValue;
-    } else if (ffValueString.toLowerCase() === "true") {
-      return true;
-    } else if (ffValueString.toLowerCase() === "false") {
-      return false;
-    } else {
-      return featureFlag.defaultValue;
-    }
-  }
-
-  isFeatureFlagEnabled(featureFlagId: string) {
-    return this.getFeatureFlagValue(featureFlagId) == true;
-  }
-
-  isFeatureFlagDisabled(featureFlagId: string) {
-    return this.getFeatureFlagValue(featureFlagId) == false;
-  }
-
-  resetFeatureFlagValue(featureFlagId: string) {
-    localStorage.removeItem(
-      this.getLocalStorageKeyFromFeatureFlagId(featureFlagId),
-    );
-  }
-
-  setFeatureFlagValue(featureFlagId: string, value: boolean) {
-    localStorage.setItem(
-      this.getLocalStorageKeyFromFeatureFlagId(featureFlagId),
-      value ? "true" : "false",
-    );
-  }
-
-  enableFeatureFlag(featureFlagId: string) {
-    this.setFeatureFlagValue(featureFlagId, true);
-  }
-
-  disableFeatureFlag(featureFlagId: string) {
-    this.setFeatureFlagValue(featureFlagId, false);
+  } catch {
+    return featureFlag.defaultValue;
   }
 }
 
-const featureFlagsManager = new FeatureFlagsManager();
+function writeFeatureFlagValue(featureFlagId: string, value: boolean) {
+  window.localStorage.setItem(
+    buildFeatureFlagStorageKey(featureFlagId),
+    value ? "true" : "false",
+  );
+}
 
 export function useFeatureFlag(
   featureFlagId: string,
-): [boolean, boolean, (newValue: boolean) => void, () => void] {
-  const [isLoading, setIsLoading] = useState(true);
-  const [refresh, setRefresh] = useState<boolean>(false);
+): [boolean, (newValue: boolean) => void] {
+  const defaultValue = getFeatureById(featureFlagId).defaultValue;
+  const [value, setValue] = useState(defaultValue);
 
   useEffect(() => {
-    if (localStorage != undefined) {
-      setIsLoading(false);
-    }
-  }, []);
+    setValue(readFeatureFlagValue(featureFlagId));
+  }, [featureFlagId]);
 
-  if (isLoading) {
-    return [
-      isLoading,
-      featureFlagsManager.getFeatureById(featureFlagId).defaultValue,
-      (_) => {},
-      () => {},
-    ];
-  } else {
-    return [
-      isLoading,
-      featureFlagsManager.getFeatureFlagValue(featureFlagId),
-      (newValue: boolean) => {
-        featureFlagsManager.setFeatureFlagValue(featureFlagId, newValue);
-        setRefresh(!refresh);
-      },
-      () => {
-        featureFlagsManager.resetFeatureFlagValue(featureFlagId);
-        setRefresh(!refresh);
-      },
-    ];
-  }
+  const updateValue = useCallback(
+    (newValue: boolean) => {
+      writeFeatureFlagValue(featureFlagId, newValue);
+      setValue(newValue);
+    },
+    [featureFlagId],
+  );
+
+  return [value, updateValue];
 }

--- a/tests/functional/tools/calendar-drill/calendar-drill.helpers.ts
+++ b/tests/functional/tools/calendar-drill/calendar-drill.helpers.ts
@@ -101,6 +101,7 @@ export class CalendarDrillPageObject {
   async goto() {
     await this.page.goto("/tools/calendar-drill");
     await expect(this.page.getByRole("heading", { name: "Calendar Drill" })).toBeVisible();
+    await expect(this.startButton).toBeVisible();
   }
 
   async start() {

--- a/tests/functional/tools/epub-maker/epub-maker.helpers.ts
+++ b/tests/functional/tools/epub-maker/epub-maker.helpers.ts
@@ -76,6 +76,7 @@ export class EpubMakerPageObject {
   async goto() {
     await this.page.goto("/tools/epub-maker");
     await expect(this.page.getByRole("heading", { name: "EPUB Maker" })).toBeVisible();
+    await expect(this.addPastedContentButton).toBeVisible();
   }
 
   async addTextPage(content: string) {


### PR DESCRIPTION
## Summary
- Render tool details before client hydration for EPUB Maker and Calendar Drill pages
- Fix Calendar Drill persisted settings hydration behavior
- Wait for hydrated tool controls in functional page objects before interacting with client-only UIs

## Validation
- yarn typecheck
- yarn test:functional tests/functional/tools/epub-maker/keyboard-and-paste.spec.ts
- yarn playwright test -c playwright.functional.config.ts tests/functional/tools/epub-maker/keyboard-and-paste.spec.ts --repeat-each=3
- yarn test:functional tests/functional/tools/calendar-drill/workflow.spec.ts