### PR TITLE
Use Chakra built-ins for shared UI patterns

### DIFF
--- a/src/app/(home)/blogs/BlogsClient.tsx
+++ b/src/app/(home)/blogs/BlogsClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { EmptyState, VStack, Spacer, Box, Icon } from "@chakra-ui/react";
+import { Bleed, EmptyState, VStack, Spacer, Box, Icon } from "@chakra-ui/react";
 import { Heading1, SectionText, SubtitleText } from "@components/core/Texts";
 import { TileList, TitleDescriptionMetaTile } from "@components/core/Tiles";
 import HighlightedSection from "@components/page/common/HighlightedSection";
@@ -27,41 +27,45 @@ function Main() {
 
 function NoBlogsElement() {
   return (
-    <HighlightedSection>
-      <EmptyState.Root>
-        <EmptyState.Content>
-          <EmptyState.Indicator>
-            <Icon boxSize={12} color={"gray.500"}>
-              <FiBookmark />
-            </Icon>
-          </EmptyState.Indicator>
-          <EmptyState.Title textAlign={"center"}>
-            {BlogsData.blogsPage.emptyStateTitle}
-          </EmptyState.Title>
-        </EmptyState.Content>
-      </EmptyState.Root>
-    </HighlightedSection>
+    <Bleed inline={{ base: 1, md: 2 }}>
+      <HighlightedSection>
+        <EmptyState.Root>
+          <EmptyState.Content>
+            <EmptyState.Indicator>
+              <Icon boxSize={12} color={"gray.500"}>
+                <FiBookmark />
+              </Icon>
+            </EmptyState.Indicator>
+            <EmptyState.Title textAlign={"center"}>
+              {BlogsData.blogsPage.emptyStateTitle}
+            </EmptyState.Title>
+          </EmptyState.Content>
+        </EmptyState.Root>
+      </HighlightedSection>
+    </Bleed>
   );
 }
 
 function BlogsListElement({ blogs }: { blogs: BlogMeta[] }) {
   return (
-    <HighlightedSection>
-      <TileList>
-        {blogs.map((blog) => (
-          <TitleDescriptionMetaTile
-            key={blog.id}
-            title={blog.title}
-            description={blog.description}
-            tags={blog.tags}
-            published={blog.published}
-            updated={blog.updated}
-            url={homepageTabs.blogs.getSubpagePathname(blog.id)}
-            isUrlExternal={false}
-          />
-        ))}
-      </TileList>
-    </HighlightedSection>
+    <Bleed inline={{ base: 1, md: 2 }}>
+      <HighlightedSection>
+        <TileList>
+          {blogs.map((blog) => (
+            <TitleDescriptionMetaTile
+              key={blog.id}
+              title={blog.title}
+              description={blog.description}
+              tags={blog.tags}
+              published={blog.published}
+              updated={blog.updated}
+              url={homepageTabs.blogs.getSubpagePathname(blog.id)}
+              isUrlExternal={false}
+            />
+          ))}
+        </TileList>
+      </HighlightedSection>
+    </Bleed>
   );
 }
 

--- a/src/app/(home)/page.tsx
+++ b/src/app/(home)/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import {
+  Bleed,
   EmptyState,
   VStack,
   HStack,
@@ -48,46 +49,52 @@ function Projects() {
 
   if (forceEmptyStates || ProjectsData.allProjects.length == 0) {
     return (
-      <HighlightedSection title="Projects">
-        <EmptyState.Root>
-          <EmptyState.Content>
-            <EmptyState.Indicator>
-              <Icon as={FiTool} boxSize={12} color={"gray.500"} />
-            </EmptyState.Indicator>
-            <EmptyState.Title textAlign={"center"}>
-              {ProjectsData.projectsPage.emptyStateTitle}
-            </EmptyState.Title>
-          </EmptyState.Content>
-        </EmptyState.Root>
-      </HighlightedSection>
+      <Bleed inline={{ base: 1, md: 2 }}>
+        <HighlightedSection title="Projects">
+          <EmptyState.Root>
+            <EmptyState.Content>
+              <EmptyState.Indicator>
+                <Icon as={FiTool} boxSize={12} color={"gray.500"} />
+              </EmptyState.Indicator>
+              <EmptyState.Title textAlign={"center"}>
+                {ProjectsData.projectsPage.emptyStateTitle}
+              </EmptyState.Title>
+            </EmptyState.Content>
+          </EmptyState.Root>
+        </HighlightedSection>
+      </Bleed>
     );
   }
 
   return (
-    <HighlightedSection
-      title="Projects"
-      titleActionElement={
-        <SectionActionLink
-          icon={FiChevronRight}
-          url={homepageTabs.projects.pathname}
-        >
-          View All
-        </SectionActionLink>
-      }
-      separateHeader
-    >
-      <TileList>
-        {ProjectsData.allProjects.slice(0, 3).map((project) => (
-          <TitleDescriptionTile
-            key={project.id}
-            title={project.title}
-            description={project.description}
-            url={project.url ?? homepageTabs.projects.getSubpagePathname(project.id)}
-            isUrlExternal={project.url ? !project.url.startsWith("/") : false}
-          />
-        ))}
-      </TileList>
-    </HighlightedSection>
+    <Bleed inline={{ base: 1, md: 2 }}>
+      <HighlightedSection
+        title="Projects"
+        titleActionElement={
+          <SectionActionLink
+            icon={FiChevronRight}
+            url={homepageTabs.projects.pathname}
+          >
+            View All
+          </SectionActionLink>
+        }
+        separateHeader
+      >
+        <TileList>
+          {ProjectsData.allProjects.slice(0, 3).map((project) => (
+            <TitleDescriptionTile
+              key={project.id}
+              title={project.title}
+              description={project.description}
+              url={
+                project.url ?? homepageTabs.projects.getSubpagePathname(project.id)
+              }
+              isUrlExternal={project.url ? !project.url.startsWith("/") : false}
+            />
+          ))}
+        </TileList>
+      </HighlightedSection>
+    </Bleed>
   );
 }
 
@@ -119,37 +126,41 @@ function WorkExperience() {
 
   if (forceEmptyStates) {
     return (
-      <HighlightedSection title="Work Experience">
-        <EmptyState.Root>
-          <EmptyState.Content>
-            <EmptyState.Indicator>
-              <Icon as={FiBriefcase} boxSize={12} color={"gray.500"} />
-            </EmptyState.Indicator>
-            <EmptyState.Title textAlign={"center"}>
-              {WorkData.emptyStateTitle}
-            </EmptyState.Title>
-          </EmptyState.Content>
-        </EmptyState.Root>
-      </HighlightedSection>
+      <Bleed inline={{ base: 1, md: 2 }}>
+        <HighlightedSection title="Work Experience">
+          <EmptyState.Root>
+            <EmptyState.Content>
+              <EmptyState.Indicator>
+                <Icon as={FiBriefcase} boxSize={12} color={"gray.500"} />
+              </EmptyState.Indicator>
+              <EmptyState.Title textAlign={"center"}>
+                {WorkData.emptyStateTitle}
+              </EmptyState.Title>
+            </EmptyState.Content>
+          </EmptyState.Root>
+        </HighlightedSection>
+      </Bleed>
     );
   }
 
   return (
-    <HighlightedSection title="Work Experience" separateHeader>
-      <TileList>
-        {WorkData.experience.map((exp, index) => (
-          <TitleDescriptionAvatarTile
-            key={index}
-            title={exp.company.name}
-            description={`${exp.role} · ${getTimeStringFromExp(exp)}`}
-            avatarSrc={exp.company.logoSrc}
-            url={exp.url}
-            compact
-            isUrlExternal
-          />
-        ))}
-      </TileList>
-    </HighlightedSection>
+    <Bleed inline={{ base: 1, md: 2 }}>
+      <HighlightedSection title="Work Experience" separateHeader>
+        <TileList>
+          {WorkData.experience.map((exp, index) => (
+            <TitleDescriptionAvatarTile
+              key={index}
+              title={exp.company.name}
+              description={`${exp.role} · ${getTimeStringFromExp(exp)}`}
+              avatarSrc={exp.company.logoSrc}
+              url={exp.url}
+              compact
+              isUrlExternal
+            />
+          ))}
+        </TileList>
+      </HighlightedSection>
+    </Bleed>
   );
 }
 

--- a/src/app/(home)/projects/ProjectsClient.tsx
+++ b/src/app/(home)/projects/ProjectsClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { EmptyState, VStack, Spacer, Box, Icon } from "@chakra-ui/react";
+import { Bleed, EmptyState, VStack, Spacer, Box, Icon } from "@chakra-ui/react";
 import { Heading1, SectionText, SubtitleText } from "@components/core/Texts";
 import { TileList, TitleDescriptionTile } from "@components/core/Tiles";
 import HighlightedSection from "@components/page/common/HighlightedSection";
@@ -26,20 +26,22 @@ function Main() {
 
 function NoProjectsElement() {
   return (
-    <HighlightedSection>
-      <EmptyState.Root>
-        <EmptyState.Content>
-          <EmptyState.Indicator>
-            <Icon boxSize={12} color={"gray.500"}>
-              <FiTool />
-            </Icon>
-          </EmptyState.Indicator>
-          <EmptyState.Title textAlign={"center"}>
-            {ProjectsData.projectsPage.emptyStateTitle}
-          </EmptyState.Title>
-        </EmptyState.Content>
-      </EmptyState.Root>
-    </HighlightedSection>
+    <Bleed inline={{ base: 1, md: 2 }}>
+      <HighlightedSection>
+        <EmptyState.Root>
+          <EmptyState.Content>
+            <EmptyState.Indicator>
+              <Icon boxSize={12} color={"gray.500"}>
+                <FiTool />
+              </Icon>
+            </EmptyState.Indicator>
+            <EmptyState.Title textAlign={"center"}>
+              {ProjectsData.projectsPage.emptyStateTitle}
+            </EmptyState.Title>
+          </EmptyState.Content>
+        </EmptyState.Root>
+      </HighlightedSection>
+    </Bleed>
   );
 }
 
@@ -53,26 +55,28 @@ function ProjectsListElement({
   const projectDetailsIdsSet = new Set(projectIdsWithDetails);
 
   return (
-    <HighlightedSection>
-      <TileList>
-        {projects.map((project) => {
-          const hasDetails = projectDetailsIdsSet.has(project.id);
-          return (
-            <TitleDescriptionTile
-              key={project.id}
-              title={project.title}
-              description={project.description}
-              url={
-                hasDetails
-                  ? homepageTabs.projects.getSubpagePathname(project.id)
-                  : project.url
-              }
-              isUrlExternal={!hasDetails}
-            />
-          );
-        })}
-      </TileList>
-    </HighlightedSection>
+    <Bleed inline={{ base: 1, md: 2 }}>
+      <HighlightedSection>
+        <TileList>
+          {projects.map((project) => {
+            const hasDetails = projectDetailsIdsSet.has(project.id);
+            return (
+              <TitleDescriptionTile
+                key={project.id}
+                title={project.title}
+                description={project.description}
+                url={
+                  hasDetails
+                    ? homepageTabs.projects.getSubpagePathname(project.id)
+                    : project.url
+                }
+                isUrlExternal={!hasDetails}
+              />
+            );
+          })}
+        </TileList>
+      </HighlightedSection>
+    </Bleed>
   );
 }
 

--- a/src/app/features/page.tsx
+++ b/src/app/features/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { EmptyState, VStack, Spacer, Box, Icon } from "@chakra-ui/react";
+import { Bleed, EmptyState, VStack, Spacer, Box, Icon } from "@chakra-ui/react";
 import { Heading1, SectionText, SubtitleText } from "@components/core/Texts";
 import { TileList, TitleDescriptionToggleTile } from "@components/core/Tiles";
 import HighlightedSection from "@components/page/common/HighlightedSection";
@@ -26,18 +26,20 @@ function Main() {
 
 function NoFeatureFlagsElement() {
   return (
-    <HighlightedSection>
-      <EmptyState.Root>
-        <EmptyState.Content>
-          <EmptyState.Indicator>
-            <Icon as={FiTool} boxSize={12} color={"gray.500"} />
-          </EmptyState.Indicator>
-          <EmptyState.Title textAlign={"center"}>
-            {"There are no feature flags!"}
-          </EmptyState.Title>
-        </EmptyState.Content>
-      </EmptyState.Root>
-    </HighlightedSection>
+    <Bleed inline={{ base: 1, md: 2 }}>
+      <HighlightedSection>
+        <EmptyState.Root>
+          <EmptyState.Content>
+            <EmptyState.Indicator>
+              <Icon as={FiTool} boxSize={12} color={"gray.500"} />
+            </EmptyState.Indicator>
+            <EmptyState.Title textAlign={"center"}>
+              {"There are no feature flags!"}
+            </EmptyState.Title>
+          </EmptyState.Content>
+        </EmptyState.Root>
+      </HighlightedSection>
+    </Bleed>
   );
 }
 
@@ -56,13 +58,15 @@ function FeatureFlagTile({ featureFlag }: { featureFlag: FeatureFlagEntry }) {
 
 function FeatureFlagsListElement() {
   return (
-    <HighlightedSection>
-      <TileList>
-        {FeatureFlagsData.flags.map((flag) => (
-          <FeatureFlagTile key={flag.id} featureFlag={flag} />
-        ))}
-      </TileList>
-    </HighlightedSection>
+    <Bleed inline={{ base: 1, md: 2 }}>
+      <HighlightedSection>
+        <TileList>
+          {FeatureFlagsData.flags.map((flag) => (
+            <FeatureFlagTile key={flag.id} featureFlag={flag} />
+          ))}
+        </TileList>
+      </HighlightedSection>
+    </Bleed>
   );
 }
 

--- a/src/components/core/Cards.tsx
+++ b/src/components/core/Cards.tsx
@@ -2,7 +2,10 @@ import { Box } from "@chakra-ui/react";
 import type { BoxProps } from "@chakra-ui/react";
 import type { ReactNode } from "react";
 
-export function HeaderCard({ children }: { children: ReactNode }) {
+export function HeaderCard({
+  children,
+  ...boxProps
+}: BoxProps & { children: ReactNode }) {
   return (
     <Box
       background={"app.bg.cardHeader"}
@@ -12,6 +15,7 @@ export function HeaderCard({ children }: { children: ReactNode }) {
       borderRadius={"2xl"}
       px={4}
       py={4}
+      {...boxProps}
     >
       {children}
     </Box>
@@ -25,7 +29,7 @@ export function MainCard({ children }: { children: ReactNode }) {
       borderWidth={0}
       borderColor={"app.border.default"}
       borderRadius={"2xl"}
-      px={[2, 4]}
+      px={{ base: 3, md: 6 }}
       py={4}
     >
       {children}

--- a/src/components/core/Dividers.tsx
+++ b/src/components/core/Dividers.tsx
@@ -1,8 +1,0 @@
-import { Box } from "@chakra-ui/react";
-
-export const APP_LIST_DIVIDER_WIDTH = "2px" as const;
-export const APP_LIST_DIVIDER_COLOR = "app.border.muted" as const;
-
-export function ListDivider() {
-  return <Box h={APP_LIST_DIVIDER_WIDTH} bg={APP_LIST_DIVIDER_COLOR} />;
-}

--- a/src/components/core/Tiles.tsx
+++ b/src/components/core/Tiles.tsx
@@ -7,17 +7,14 @@ import {
   Text,
   Wrap,
   WrapItem,
+  Separator,
 } from "@chakra-ui/react";
 import NextLink from "next/link";
-import { Children } from "react";
+import { Children, Fragment } from "react";
 import { FiChevronRight, FiArrowUpRight } from "react-icons/fi";
 import { CategoryBadge } from "./Badges";
 import { Avatar } from "@components/ui/avatar";
 import { Switch } from "@components/ui/switch";
-import {
-  APP_LIST_DIVIDER_COLOR,
-  APP_LIST_DIVIDER_WIDTH,
-} from "@components/core/Dividers";
 
 type SwitchCheckedChangeDetails = {
   checked: boolean;
@@ -25,7 +22,6 @@ type SwitchCheckedChangeDetails = {
 
 function useTileColors() {
   return {
-    divider: APP_LIST_DIVIDER_COLOR,
     description: "app.fg.subtle",
     avatarBorder: "app.border.default",
     linkIcon: "app.fg.icon",
@@ -56,28 +52,20 @@ export function TileList({
   showDividerAfterLast?: boolean;
 }) {
   const items = Children.toArray(children).filter(Boolean);
-  const { divider: dividerColor } = useTileColors();
 
   return (
     <VStack
       align={"stretch"}
       gap={0}
-      borderTopWidth={showDividerBeforeFirst ? APP_LIST_DIVIDER_WIDTH : "0px"}
-      borderTopColor={dividerColor}
-      borderBottomWidth={showDividerAfterLast ? APP_LIST_DIVIDER_WIDTH : "0px"}
-      borderBottomColor={dividerColor}
     >
+      {showDividerBeforeFirst ? <Separator size={"md"} /> : null}
       {items.map((child, index) => (
-        <Box
-          key={index}
-          borderBottomWidth={
-            index < items.length - 1 ? APP_LIST_DIVIDER_WIDTH : "0px"
-          }
-          borderBottomColor={dividerColor}
-        >
+        <Fragment key={index}>
           {child}
-        </Box>
+          {index < items.length - 1 ? <Separator size={"md"} /> : null}
+        </Fragment>
       ))}
+      {showDividerAfterLast ? <Separator size={"md"} /> : null}
     </VStack>
   );
 }

--- a/src/components/core/Tiles.tsx
+++ b/src/components/core/Tiles.tsx
@@ -4,13 +4,15 @@ import {
   Icon,
   useBreakpointValue,
   Box,
+  LinkBox,
+  LinkOverlay,
   Text,
   Wrap,
   WrapItem,
   Separator,
 } from "@chakra-ui/react";
 import NextLink from "next/link";
-import { Children, Fragment } from "react";
+import { Children, Fragment, type ReactNode } from "react";
 import { FiChevronRight, FiArrowUpRight } from "react-icons/fi";
 import { CategoryBadge } from "./Badges";
 import { Avatar } from "@components/ui/avatar";
@@ -70,34 +72,35 @@ export function TileList({
   );
 }
 
-function LinkOverlayIfUrlPresent({
+function TileLinkIfUrlPresent({
   children,
   url,
+  label,
   isUrlExternal,
 }: {
-  children: any;
+  children: ReactNode;
   url?: string;
+  label: string;
   isUrlExternal?: boolean;
 }) {
   if (!url) return <>{children}</>;
 
-  if (isUrlExternal) {
-    return (
-      <a
-        href={url}
-        target="_blank"
-        rel="noopener noreferrer"
-        style={{ display: "block" }}
-      >
-        {children}
-      </a>
-    );
-  }
+  const overlay = isUrlExternal ? (
+    <LinkOverlay
+      aria-label={label}
+      href={url}
+      target="_blank"
+      rel="noopener noreferrer"
+    />
+  ) : (
+    <LinkOverlay as={NextLink} aria-label={label} href={url} />
+  );
 
   return (
-    <NextLink href={url} style={{ display: "block" }}>
+    <LinkBox>
       {children}
-    </NextLink>
+      {overlay}
+    </LinkBox>
   );
 }
 
@@ -132,7 +135,11 @@ export function TitleDescriptionAvatarTile({
   const descriptionJsx = <Text color={descriptionColor}>{description}</Text>;
 
   return (
-    <LinkOverlayIfUrlPresent url={url} isUrlExternal={isUrlExternal}>
+    <TileLinkIfUrlPresent
+      url={url}
+      label={title}
+      isUrlExternal={isUrlExternal}
+    >
       <FlatTile compact={compact}>
         <VStack align={"stretch"} gap={compact ? 2 : 2}>
           <HStack justify={"space-between"}>
@@ -157,7 +164,7 @@ export function TitleDescriptionAvatarTile({
           {showDescriptionBelow ? descriptionJsx : null}
         </VStack>
       </FlatTile>
-    </LinkOverlayIfUrlPresent>
+    </TileLinkIfUrlPresent>
   );
 }
 
@@ -223,7 +230,11 @@ export function TitleDescriptionTile({
   const descriptionJsx = <Text color={descriptionColor}>{description}</Text>;
 
   return (
-    <LinkOverlayIfUrlPresent url={url} isUrlExternal={isUrlExternal}>
+    <TileLinkIfUrlPresent
+      url={url}
+      label={title}
+      isUrlExternal={isUrlExternal}
+    >
       <FlatTile>
         <VStack align={"stretch"}>
           <HStack justify={"space-between"} align={"start"}>
@@ -237,7 +248,7 @@ export function TitleDescriptionTile({
           </HStack>
         </VStack>
       </FlatTile>
-    </LinkOverlayIfUrlPresent>
+    </TileLinkIfUrlPresent>
   );
 }
 
@@ -265,7 +276,11 @@ export function TitleDescriptionMetaTile({
   const metadataLabel = formatBlogDateLabel({ published, updated });
 
   return (
-    <LinkOverlayIfUrlPresent url={url} isUrlExternal={isUrlExternal}>
+    <TileLinkIfUrlPresent
+      url={url}
+      label={title}
+      isUrlExternal={isUrlExternal}
+    >
       <FlatTile>
         <VStack align={"stretch"} gap={2}>
           <HStack justify={"space-between"} align={"start"}>
@@ -295,7 +310,7 @@ export function TitleDescriptionMetaTile({
           ) : null}
         </VStack>
       </FlatTile>
-    </LinkOverlayIfUrlPresent>
+    </TileLinkIfUrlPresent>
   );
 }
 
@@ -324,7 +339,11 @@ export function TitleCategoryAvatarTile({
   );
 
   return (
-    <LinkOverlayIfUrlPresent url={url} isUrlExternal={isUrlExternal}>
+    <TileLinkIfUrlPresent
+      url={url}
+      label={title}
+      isUrlExternal={isUrlExternal}
+    >
       <FlatTile>
         <VStack align={"stretch"}>
           <HStack justify={"space-between"}>
@@ -351,7 +370,7 @@ export function TitleCategoryAvatarTile({
           <Box>{showBadgeBelow ? categoryRow : null}</Box>
         </VStack>
       </FlatTile>
-    </LinkOverlayIfUrlPresent>
+    </TileLinkIfUrlPresent>
   );
 }
 
@@ -404,7 +423,11 @@ export function TitleDescriptionToggleTile({
   const descriptionJsx = <Text color={descriptionColor}>{description}</Text>;
 
   return (
-    <LinkOverlayIfUrlPresent url={url} isUrlExternal={isUrlExternal}>
+    <TileLinkIfUrlPresent
+      url={url}
+      label={title}
+      isUrlExternal={isUrlExternal}
+    >
       <FlatTile>
         <VStack align={"stretch"}>
           <HStack justify={"space-between"}>
@@ -424,6 +447,6 @@ export function TitleDescriptionToggleTile({
           </HStack>
         </VStack>
       </FlatTile>
-    </LinkOverlayIfUrlPresent>
+    </TileLinkIfUrlPresent>
   );
 }

--- a/src/components/core/Tiles.tsx
+++ b/src/components/core/Tiles.tsx
@@ -36,7 +36,7 @@ function FlatTile({
   compact?: boolean;
 }) {
   return (
-    <Box px={[1, 2]} py={compact ? [2, 2] : [2, 3]}>
+    <Box px={0} py={compact ? [2, 2] : [2, 3]}>
       {children}
     </Box>
   );
@@ -154,7 +154,7 @@ export function TitleDescriptionAvatarTile({
             </HStack>
             {url ? <LinkHelperIcon isExternal={isUrlExternal} /> : null}
           </HStack>
-          <Box mx={compact ? 1 : 2}>{showDescriptionBelow ? descriptionJsx : null}</Box>
+          {showDescriptionBelow ? descriptionJsx : null}
         </VStack>
       </FlatTile>
     </LinkOverlayIfUrlPresent>

--- a/src/components/page/common/Footer.tsx
+++ b/src/components/page/common/Footer.tsx
@@ -77,9 +77,9 @@ export default function Footer({
 
   return (
     <Box as="footer" p={[1, 4]} pt={[0, 0.5]} role="contentinfo">
-      <HeaderCard>
-        <VStack align="stretch" gap={4}>
-          <Box px={[3, 5]} py={[3, 4]}>
+      <HeaderCard px={0} py={0} overflow={"hidden"}>
+        <VStack align="stretch" gap={0}>
+          <Box px={[7, 9]} py={[7, 8]}>
             <Stack
               direction={["column", "row"]}
               justify="space-between"
@@ -184,11 +184,8 @@ export default function Footer({
               background={"app.bg.cardHeader"}
               borderTopWidth={"2px"}
               borderTopColor={"app.border.default"}
-              mx={-4}
-              mb={-4}
-              px={[4, 6]}
+              px={[7, 9]}
               py={3}
-              borderBottomRadius={"2xl"}
             >
               <Text
                 fontSize={"sm"}

--- a/src/components/page/cv/CvLanguagesSection.tsx
+++ b/src/components/page/cv/CvLanguagesSection.tsx
@@ -1,6 +1,5 @@
-import { Box, HStack, Text, VStack } from "@chakra-ui/react";
+import { Box, HStack, Separator, Text, VStack } from "@chakra-ui/react";
 import { Heading4 } from "@components/core/Texts";
-import { ListDivider } from "@components/core/Dividers";
 import type { CvLanguageItem, CvSectionBase } from "data/cv";
 import type { ElementType } from "react";
 import CvSection from "./CvSection";
@@ -106,9 +105,7 @@ export default function CvLanguagesSection({
               </HStack>
             </VStack>
 
-            {index < section.items.length - 1 ? (
-              <ListDivider />
-            ) : null}
+            {index < section.items.length - 1 ? <Separator size="md" /> : null}
           </VStack>
         ))}
       </VStack>

--- a/src/components/page/cv/CvProjectsSection.tsx
+++ b/src/components/page/cv/CvProjectsSection.tsx
@@ -6,10 +6,10 @@ import {
   Wrap,
   WrapItem,
   Icon,
+  Separator,
 } from "@chakra-ui/react";
 import { Heading4 } from "@components/core/Texts";
 import { CategoryBadge, FeaturedIndicator } from "@components/core/Badges";
-import { ListDivider } from "@components/core/Dividers";
 import type { CvSectionBase, CvProjectItem } from "data/cv";
 import type { ElementType } from "react";
 import { FiLink } from "react-icons/fi";
@@ -146,9 +146,7 @@ export default function CvProjectsSection({
         {section.items.map((item, index) => (
           <VStack key={`${item.name}-${index}`} align="stretch" gap={4}>
             <ProjectCard item={item} accentColorPalette={accentColorPalette} />
-            {index < section.items.length - 1 ? (
-              <ListDivider />
-            ) : null}
+            {index < section.items.length - 1 ? <Separator size="md" /> : null}
           </VStack>
         ))}
       </VStack>

--- a/src/components/page/cv/CvSection.tsx
+++ b/src/components/page/cv/CvSection.tsx
@@ -1,4 +1,4 @@
-import { Box, VStack, Text } from "@chakra-ui/react";
+import { Bleed, Box, VStack, Text } from "@chakra-ui/react";
 import HighlightedSection from "@components/page/common/HighlightedSection";
 import { HEADER_OFFSET_HEIGHT } from "@components/page/common/Header";
 import type { ReactNode } from "react";
@@ -25,26 +25,28 @@ export default function CvSection({
 }) {
   return (
     <Box id={id} scrollMarginTop={HEADER_OFFSET_HEIGHT}>
-      <HighlightedSection
-        title={title}
-        titleIcon={titleIcon}
-        primaryColorPalette={primaryColorPalette}
-        accentColorPalette={accentColorPalette}
-        separateHeader
-      >
-        <VStack align={"stretch"} gap={3}>
-          {description ? (
-            <Text
-              fontSize={CV_META_TEXT_SIZE}
-              color={"app.fg.subtle"}
-              fontFamily={CV_CMU_FONT_FAMILY}
-            >
-              {description}
-            </Text>
-          ) : null}
-          {children}
-        </VStack>
-      </HighlightedSection>
+      <Bleed inline={{ base: 1, md: 2 }}>
+        <HighlightedSection
+          title={title}
+          titleIcon={titleIcon}
+          primaryColorPalette={primaryColorPalette}
+          accentColorPalette={accentColorPalette}
+          separateHeader
+        >
+          <VStack align={"stretch"} gap={3}>
+            {description ? (
+              <Text
+                fontSize={CV_META_TEXT_SIZE}
+                color={"app.fg.subtle"}
+                fontFamily={CV_CMU_FONT_FAMILY}
+              >
+                {description}
+              </Text>
+            ) : null}
+            {children}
+          </VStack>
+        </HighlightedSection>
+      </Bleed>
     </Box>
   );
 }

--- a/src/components/page/cv/CvTimelineSection.tsx
+++ b/src/components/page/cv/CvTimelineSection.tsx
@@ -7,10 +7,10 @@ import {
   WrapItem,
   Icon,
   Box,
+  Separator,
 } from "@chakra-ui/react";
 import { Heading4 } from "@components/core/Texts";
 import { CategoryBadge } from "@components/core/Badges";
-import { ListDivider } from "@components/core/Dividers";
 import type { CvSectionBase, CvTimelineItem } from "data/cv";
 import { FiLink } from "react-icons/fi";
 import CvSection from "./CvSection";
@@ -214,7 +214,7 @@ export default function CvTimelineSection({
             />
             {index < section.items.length - 1 ? (
               <Box pl={6}>
-                <ListDivider />
+                <Separator size="md" />
               </Box>
             ) : null}
           </VStack>

--- a/src/components/ui/field.tsx
+++ b/src/components/ui/field.tsx
@@ -1,5 +1,5 @@
 import { Field as ChakraField, Fieldset as ChakraFieldset } from "@chakra-ui/react";
-import type React from "react";
+import * as React from "react";
 import type { ReactNode } from "react";
 
 const FieldLabel = ChakraField.Label as React.ComponentType<{
@@ -10,10 +10,58 @@ const FieldsetLegend = ChakraFieldset.Legend as React.ComponentType<{
   children?: ReactNode;
 }>;
 
-export const Field = {
+export interface FieldProps extends Omit<ChakraField.RootProps, "label"> {
+  label?: ReactNode;
+  helperText?: ReactNode;
+  errorText?: ReactNode;
+  optionalText?: ReactNode;
+  labelProps?: ChakraField.LabelProps;
+  helperTextProps?: ChakraField.HelperTextProps;
+  errorTextProps?: ChakraField.ErrorTextProps;
+}
+
+const FieldRoot = React.forwardRef<HTMLDivElement, FieldProps>(
+  function FieldRoot(props, ref) {
+    const {
+      label,
+      children,
+      helperText,
+      errorText,
+      optionalText,
+      labelProps,
+      helperTextProps,
+      errorTextProps,
+      ...rest
+    } = props;
+
+    return (
+      <ChakraField.Root ref={ref} {...rest}>
+        {label ? (
+          <ChakraField.Label {...labelProps}>
+            {label}
+            <ChakraField.RequiredIndicator fallback={optionalText} />
+          </ChakraField.Label>
+        ) : null}
+        {children}
+        {helperText ? (
+          <ChakraField.HelperText {...helperTextProps}>
+            {helperText}
+          </ChakraField.HelperText>
+        ) : null}
+        {errorText ? (
+          <ChakraField.ErrorText {...errorTextProps}>
+            {errorText}
+          </ChakraField.ErrorText>
+        ) : null}
+      </ChakraField.Root>
+    );
+  },
+);
+
+export const Field = Object.assign(FieldRoot, {
   ...ChakraField,
   Label: FieldLabel,
-};
+});
 
 export const Fieldset = {
   ...ChakraFieldset,

--- a/src/config/chakra/index.ts
+++ b/src/config/chakra/index.ts
@@ -1,5 +1,16 @@
-import { createSystem, defaultConfig, defineConfig } from "@chakra-ui/react";
+import {
+  createSystem,
+  defaultConfig,
+  defineConfig,
+  defineRecipe,
+} from "@chakra-ui/react";
 import { APP_SEMANTIC_COLOR_TOKENS } from "./semantic-tokens";
+
+const separatorRecipe = defineRecipe({
+  base: {
+    borderColor: "app.border.muted",
+  },
+});
 
 const config = defineConfig({
   theme: {
@@ -13,6 +24,9 @@ const config = defineConfig({
     },
     semanticTokens: {
       colors: APP_SEMANTIC_COLOR_TOKENS,
+    },
+    recipes: {
+      separator: separatorRecipe,
     },
   },
 });

--- a/src/features/calendar-drill/components/CalendarDrillPage.tsx
+++ b/src/features/calendar-drill/components/CalendarDrillPage.tsx
@@ -5,6 +5,7 @@ import {
   Box,
   Button,
   Card,
+  Collapsible,
   Grid,
   HStack,
   Icon,
@@ -714,62 +715,64 @@ export function CalendarDrillPage() {
                               </Button>
                             </Grid>
 
-                            <VStack align={"stretch"} gap={3}>
-                              <Button
-                                w={"full"}
-                                variant={"ghost"}
-                                justifyContent={"space-between"}
-                                rounded={"xl"}
-                                px={3}
-                                h={"auto"}
-                                py={3}
-                                minW={0}
-                                overflow={"hidden"}
-                                onClick={() =>
-                                  setIsAdvancedSettingsOpen(
-                                    (current) => !current,
-                                  )
-                                }
-                                aria-expanded={isAdvancedSettingsOpen}
-                              >
-                                <HStack
-                                  gap={3}
+                            <Collapsible.Root
+                              open={isAdvancedSettingsOpen}
+                              onOpenChange={(details) =>
+                                setIsAdvancedSettingsOpen(details.open)
+                              }
+                            >
+                              <Collapsible.Trigger asChild>
+                                <Button
+                                  w={"full"}
+                                  variant={"ghost"}
+                                  justifyContent={"space-between"}
+                                  rounded={"xl"}
+                                  px={3}
+                                  h={"auto"}
+                                  py={3}
                                   minW={0}
-                                  flex={1}
                                   overflow={"hidden"}
                                 >
-                                  <Icon as={LuSettings2} flexShrink={0} />
-                                  <VStack
-                                    align={"start"}
-                                    gap={0}
+                                  <HStack
+                                    gap={3}
                                     minW={0}
                                     flex={1}
                                     overflow={"hidden"}
                                   >
-                                    <Text>Advanced Settings</Text>
-                                    <Text
-                                      fontSize={"xs"}
-                                      color={"app.fg.subtle"}
-                                      maxW={"full"}
-                                      truncate
+                                    <Icon as={LuSettings2} flexShrink={0} />
+                                    <VStack
+                                      align={"start"}
+                                      gap={0}
+                                      minW={0}
+                                      flex={1}
+                                      overflow={"hidden"}
                                     >
-                                      {advancedSettingsSummary}
-                                    </Text>
-                                  </VStack>
-                                </HStack>
-                                <Icon
-                                  as={LuChevronDown}
-                                  flexShrink={0}
-                                  transform={
-                                    isAdvancedSettingsOpen
-                                      ? "rotate(180deg)"
-                                      : undefined
-                                  }
-                                  transition={"transform 0.15s ease"}
-                                />
-                              </Button>
+                                      <Text>Advanced Settings</Text>
+                                      <Text
+                                        fontSize={"xs"}
+                                        color={"app.fg.subtle"}
+                                        maxW={"full"}
+                                        truncate
+                                      >
+                                        {advancedSettingsSummary}
+                                      </Text>
+                                    </VStack>
+                                  </HStack>
+                                  <Collapsible.Indicator asChild>
+                                    <Icon
+                                      as={LuChevronDown}
+                                      flexShrink={0}
+                                      transition={"transform 0.15s ease"}
+                                      _open={{ transform: "rotate(180deg)" }}
+                                    />
+                                  </Collapsible.Indicator>
+                                </Button>
+                              </Collapsible.Trigger>
 
-                              {isAdvancedSettingsOpen ? (
+                              <Collapsible.Content
+                                pt={3}
+                                _open={{ overflow: "visible" }}
+                              >
                                 <VStack
                                   align={"stretch"}
                                   gap={5}
@@ -993,8 +996,8 @@ export function CalendarDrillPage() {
                                     </Grid>
                                   </VStack>
                                 </VStack>
-                              ) : null}
-                            </VStack>
+                              </Collapsible.Content>
+                            </Collapsible.Root>
                           </VStack>
                         </Fieldset.Content>
                       </Fieldset.Root>

--- a/src/features/calendar-drill/components/CalendarDrillPage.tsx
+++ b/src/features/calendar-drill/components/CalendarDrillPage.tsx
@@ -8,6 +8,7 @@ import {
   HStack,
   Icon,
   NativeSelect,
+  Separator,
   Text,
   VStack,
 } from "@chakra-ui/react";
@@ -819,11 +820,7 @@ export function CalendarDrillPage() {
                                     </Field.Root>
                                   </VStack>
 
-                                  <Box
-                                    h={"1px"}
-                                    bg={"app.border.default"}
-                                    aria-hidden={"true"}
-                                  />
+                                  <Separator />
 
                                   <VStack align={"stretch"} gap={3}>
                                     <HStack
@@ -932,11 +929,7 @@ export function CalendarDrillPage() {
                                     </Grid>
                                   </VStack>
 
-                                  <Box
-                                    h={"1px"}
-                                    bg={"app.border.default"}
-                                    aria-hidden={"true"}
-                                  />
+                                  <Separator />
 
                                   <VStack align={"stretch"} gap={3}>
                                     <HStack gap={2}>

--- a/src/features/calendar-drill/components/CalendarDrillPage.tsx
+++ b/src/features/calendar-drill/components/CalendarDrillPage.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import {
+  Bleed,
   Box,
   Button,
   Card,
@@ -520,12 +521,15 @@ export function CalendarDrillPage() {
             streak={stats.streak}
             trends={trends}
           />
+        </VStack>
+      </Box>
 
-          <Box mx={{ base: -4, md: -6 }}>
-            <HighlightedSection
-              contentPx={{ base: 3, md: 4 }}
-              contentPy={{ base: 3, md: 4 }}
-            >
+      <Box>
+        <Bleed inline={{ base: 1, md: 2 }}>
+          <HighlightedSection
+            contentPx={{ base: 3, md: 4 }}
+            contentPy={{ base: 3, md: 4 }}
+          >
               <Card.Root
                 borderColor={"app.border.default"}
                 rounded={"2xl"}
@@ -1077,9 +1081,8 @@ export function CalendarDrillPage() {
                   )}
                 </Card.Footer>
               </Card.Root>
-            </HighlightedSection>
-          </Box>
-        </VStack>
+          </HighlightedSection>
+        </Bleed>
       </Box>
     </VStack>
   );

--- a/src/features/epub-maker/components/EpubMakerPageView.tsx
+++ b/src/features/epub-maker/components/EpubMakerPageView.tsx
@@ -1,4 +1,4 @@
-import { Box, Icon, Text, VStack } from "@chakra-ui/react";
+import { Bleed, Box, Icon, Text, VStack } from "@chakra-ui/react";
 import HighlightedSection from "@components/page/common/HighlightedSection";
 import { useEffect, useState, type DragEvent } from "react";
 import { LuFilePlus } from "react-icons/lu";
@@ -173,49 +173,51 @@ export function EpubMakerPageView(props: UseEpubMakerReturn) {
         onDragLeave={handleFileDragLeave}
         onDrop={handleFileDrop}
       >
-        <HighlightedSection
-          contentPx={{ base: 2, sm: 3, md: 4, lg: 6 }}
-          contentPy={{ base: 2, sm: 3, md: 4, lg: 6 }}
-        >
-          <Box minH={"340px"} px={0} py={0}>
-            <PageDraftGrid
-              pages={props.pages}
-              previewBookTitle={props.normalizedBookTitle}
-              previewBookAuthor={props.normalizedBookAuthor}
-              coverPreviewHtml={props.coverPreviewHtml}
-              coverCustomHtml={props.coverCustomHtml}
-              hasCustomCover={props.hasCustomCover}
-              coverBackgroundId={props.coverBackgroundId}
-              coverBackgroundOptions={props.coverBackgroundOptions}
-              coverSizePresetId={props.coverSizePresetId}
-              coverSizePresetOptions={props.coverSizePresetOptions}
-              coverTextScalePercent={props.coverTextScalePercent}
-              coverTextPosition={props.coverTextPosition}
-              coverTextColorMode={props.coverTextColorMode}
-              hideCoverText={props.hideCoverText}
-              isCoverEnabled={props.isCoverEnabled}
-              isAdding={props.isAdding}
-              isGenerating={props.isGenerating}
-              generationChapterStatusByPageId={
-                props.generationChapterStatusByPageId
-              }
-              activeGenerationPageId={props.activeGenerationPageId}
-              isGenerationStatusFading={props.isGenerationStatusFading}
-              pageFlashById={props.pageFlashById}
-              onRemove={props.removePage}
-              onRename={props.renamePage}
-              onReorder={props.reorderPages}
-              onApplyCoverSettings={props.applyCoverSettings}
-              onNotifyUser={props.notifyUser}
-              onAddFromClipboard={props.addPageFromClipboard}
-              onAddFromFiles={props.addPagesFromFiles}
-              pastedInput={props.pastedInput}
-              onPastedInputChange={props.setPastedInput}
-              onPaste={props.onPasteInput}
-              onAddFromFallback={props.addFromFallbackText}
-            />
-          </Box>
-        </HighlightedSection>
+        <Bleed inline={{ base: 1, md: 2 }}>
+          <HighlightedSection
+            contentPx={{ base: 2, sm: 3, md: 4, lg: 6 }}
+            contentPy={{ base: 2, sm: 3, md: 4, lg: 6 }}
+          >
+            <Box minH={"340px"} px={0} py={0}>
+              <PageDraftGrid
+                pages={props.pages}
+                previewBookTitle={props.normalizedBookTitle}
+                previewBookAuthor={props.normalizedBookAuthor}
+                coverPreviewHtml={props.coverPreviewHtml}
+                coverCustomHtml={props.coverCustomHtml}
+                hasCustomCover={props.hasCustomCover}
+                coverBackgroundId={props.coverBackgroundId}
+                coverBackgroundOptions={props.coverBackgroundOptions}
+                coverSizePresetId={props.coverSizePresetId}
+                coverSizePresetOptions={props.coverSizePresetOptions}
+                coverTextScalePercent={props.coverTextScalePercent}
+                coverTextPosition={props.coverTextPosition}
+                coverTextColorMode={props.coverTextColorMode}
+                hideCoverText={props.hideCoverText}
+                isCoverEnabled={props.isCoverEnabled}
+                isAdding={props.isAdding}
+                isGenerating={props.isGenerating}
+                generationChapterStatusByPageId={
+                  props.generationChapterStatusByPageId
+                }
+                activeGenerationPageId={props.activeGenerationPageId}
+                isGenerationStatusFading={props.isGenerationStatusFading}
+                pageFlashById={props.pageFlashById}
+                onRemove={props.removePage}
+                onRename={props.renamePage}
+                onReorder={props.reorderPages}
+                onApplyCoverSettings={props.applyCoverSettings}
+                onNotifyUser={props.notifyUser}
+                onAddFromClipboard={props.addPageFromClipboard}
+                onAddFromFiles={props.addPagesFromFiles}
+                pastedInput={props.pastedInput}
+                onPastedInputChange={props.setPastedInput}
+                onPaste={props.onPasteInput}
+                onAddFromFallback={props.addFromFallbackText}
+              />
+            </Box>
+          </HighlightedSection>
+        </Bleed>
 
         {props.isGenerating ? (
           <Box

--- a/src/features/epub-maker/components/EpubMetadataForm.tsx
+++ b/src/features/epub-maker/components/EpubMetadataForm.tsx
@@ -7,6 +7,7 @@ import {
   Input,
   Text,
 } from "@chakra-ui/react";
+import { Field } from "@components/ui/field";
 import { Switch } from "@components/ui/switch";
 import { Tooltip } from "@components/ui/tooltip";
 import { LuCircleHelp, LuSettings2 } from "react-icons/lu";
@@ -48,6 +49,12 @@ export function EpubMetadataForm({
     rounded: "xl",
   } as const;
 
+  const fieldLabelProps = {
+    fontSize: "sm",
+    color: "app.epub.fg.muted",
+    mb: 1,
+  } as const;
+
   const switchProps = {
     controlProps: {
       bg: "app.epub.switch.track.off",
@@ -64,10 +71,13 @@ export function EpubMetadataForm({
   return (
     <>
       <HStack gap={3} wrap={"wrap"} align={"stretch"}>
-        <Box minW={["full", "320px"]} flex={1}>
-          <Text fontSize={"sm"} color={"app.epub.fg.muted"} mb={1}>
-            Title (optional)
-          </Text>
+        <Field
+          label={"Title"}
+          optionalText={"(optional)"}
+          labelProps={fieldLabelProps}
+          minW={["full", "320px"]}
+          flex={1}
+        >
           <Input
             {...controlInputProps}
             placeholder={DEFAULT_BOOK_TITLE}
@@ -78,11 +88,14 @@ export function EpubMetadataForm({
             value={prefs.title}
             onChange={(event) => onTitleChange(event.target.value)}
           />
-        </Box>
-        <Box minW={["full", "260px"]} flex={1}>
-          <Text fontSize={"sm"} color={"app.epub.fg.muted"} mb={1}>
-            Author (optional)
-          </Text>
+        </Field>
+        <Field
+          label={"Author"}
+          optionalText={"(optional)"}
+          labelProps={fieldLabelProps}
+          minW={["full", "260px"]}
+          flex={1}
+        >
           <Input
             {...controlInputProps}
             placeholder={"Name"}
@@ -93,11 +106,13 @@ export function EpubMetadataForm({
             value={prefs.author}
             onChange={(event) => onAuthorChange(event.target.value)}
           />
-        </Box>
-        <Box minW={["full", "320px"]} flex={1}>
-          <Text fontSize={"sm"} color={"app.epub.fg.muted"} mb={1}>
-            File name
-          </Text>
+        </Field>
+        <Field
+          label={"File name"}
+          labelProps={fieldLabelProps}
+          minW={["full", "320px"]}
+          flex={1}
+        >
           <Group attached w={"full"}>
             <Input
               {...controlInputProps}
@@ -133,7 +148,7 @@ export function EpubMetadataForm({
               {prefs.fileNameMode === "auto" ? "Auto" : "Manual"}
             </Button>
           </Group>
-        </Box>
+        </Field>
       </HStack>
 
       <HStack gap={6} wrap={"wrap"} align={"center"}>

--- a/src/features/epub-maker/components/EpubToolbar.tsx
+++ b/src/features/epub-maker/components/EpubToolbar.tsx
@@ -5,15 +5,10 @@ import {
   HStack,
   Icon,
   IconButton,
+  Popover,
   Textarea,
 } from "@chakra-ui/react";
-import {
-  type ChangeEvent,
-  ClipboardEvent,
-  useEffect,
-  useRef,
-  useState,
-} from "react";
+import { type ChangeEvent, ClipboardEvent, useRef, useState } from "react";
 import {
   LuBookDown,
   LuCheck,
@@ -74,8 +69,6 @@ export function EpubToolbar({
   } as const;
 
   const [isManualPasteOpen, setIsManualPasteOpen] = useState(false);
-  const triggerGroupRef = useRef<HTMLDivElement | null>(null);
-  const popoverRef = useRef<HTMLDivElement | null>(null);
   const uploadInputRef = useRef<HTMLInputElement | null>(null);
   const saveProgressPercent = Math.max(
     0,
@@ -89,104 +82,78 @@ export function EpubToolbar({
     event.target.value = "";
   }
 
-  useEffect(() => {
-    if (!isManualPasteOpen) return;
-
-    function handlePointerDown(event: MouseEvent) {
-      const target = event.target as Node | null;
-      if (!target) return;
-
-      if (popoverRef.current?.contains(target)) return;
-      if (triggerGroupRef.current?.contains(target)) return;
-
-      setIsManualPasteOpen(false);
-    }
-
-    function handleEscape(event: KeyboardEvent) {
-      if (event.key === "Escape") {
-        setIsManualPasteOpen(false);
-      }
-    }
-
-    document.addEventListener("mousedown", handlePointerDown);
-    document.addEventListener("keydown", handleEscape);
-
-    return () => {
-      document.removeEventListener("mousedown", handlePointerDown);
-      document.removeEventListener("keydown", handleEscape);
-    };
-  }, [isManualPasteOpen]);
-
   return (
     <HStack gap={3} wrap={"wrap"} align={"start"}>
-      <Box position={"relative"}>
-        <HStack ref={triggerGroupRef} gap={0} align={"stretch"}>
-          <Button
-            {...actionButtonProps}
-            onClick={onAddFromClipboard}
-            loading={isAdding}
-            disabled={isGenerating}
-            roundedRight={0}
-            borderRightWidth={"0"}
-            bg={"app.epub.button.primary.bg"}
-            color={"app.epub.button.primary.fg"}
-            _hover={{ bg: "app.epub.button.primary.hoverBg" }}
-          >
-            <Icon>
-              <LuFilePlus />
-            </Icon>
-            Add from clipboard
-          </Button>
+      <Popover.Root
+        open={isManualPasteOpen}
+        onOpenChange={(details) => setIsManualPasteOpen(details.open)}
+        positioning={{ placement: "bottom-start", gutter: 6 }}
+      >
+        <Box>
+          <HStack gap={0} align={"stretch"}>
+            <Button
+              {...actionButtonProps}
+              onClick={onAddFromClipboard}
+              loading={isAdding}
+              disabled={isGenerating}
+              roundedRight={0}
+              borderRightWidth={"0"}
+              bg={"app.epub.button.primary.bg"}
+              color={"app.epub.button.primary.fg"}
+              _hover={{ bg: "app.epub.button.primary.hoverBg" }}
+            >
+              <Icon>
+                <LuFilePlus />
+              </Icon>
+              Add from clipboard
+            </Button>
 
-          <FileUpload.Root maxFiles={50}>
-            <FileUpload.HiddenInput
-              ref={uploadInputRef}
-              aria-label={"Upload files"}
-              onChange={handleUploadInputChange}
-            />
-            <Tooltip content={"Upload files"}>
+            <FileUpload.Root maxFiles={50}>
+              <FileUpload.HiddenInput
+                ref={uploadInputRef}
+                aria-label={"Upload files"}
+                onChange={handleUploadInputChange}
+              />
+              <Tooltip content={"Upload files"}>
+                <IconButton
+                  {...actionButtonProps}
+                  aria-label={"Upload files"}
+                  rounded={0}
+                  borderLeftWidth={"1px"}
+                  borderLeftColor={"app.epub.button.primary.divider"}
+                  bg={"app.epub.button.primary.bg"}
+                  color={"app.epub.button.primary.fg"}
+                  _hover={{ bg: "app.epub.button.primary.hoverBg" }}
+                  disabled={isGenerating}
+                  onClick={() => uploadInputRef.current?.click()}
+                >
+                  <LuUpload />
+                </IconButton>
+              </Tooltip>
+            </FileUpload.Root>
+
+            <Popover.Trigger asChild>
               <IconButton
                 {...actionButtonProps}
-                aria-label={"Upload files"}
-                rounded={0}
+                aria-label={
+                  isManualPasteOpen ? "Hide manual paste" : "Show manual paste"
+                }
+                roundedLeft={0}
                 borderLeftWidth={"1px"}
                 borderLeftColor={"app.epub.button.primary.divider"}
                 bg={"app.epub.button.primary.bg"}
                 color={"app.epub.button.primary.fg"}
                 _hover={{ bg: "app.epub.button.primary.hoverBg" }}
                 disabled={isGenerating}
-                onClick={() => uploadInputRef.current?.click()}
               >
-                <LuUpload />
+                {isManualPasteOpen ? <LuChevronUp /> : <LuChevronDown />}
               </IconButton>
-            </Tooltip>
-          </FileUpload.Root>
+            </Popover.Trigger>
+          </HStack>
+        </Box>
 
-          <IconButton
-            {...actionButtonProps}
-            aria-label={
-              isManualPasteOpen ? "Hide manual paste" : "Show manual paste"
-            }
-            roundedLeft={0}
-            borderLeftWidth={"1px"}
-            borderLeftColor={"app.epub.button.primary.divider"}
-            bg={"app.epub.button.primary.bg"}
-            color={"app.epub.button.primary.fg"}
-            _hover={{ bg: "app.epub.button.primary.hoverBg" }}
-            disabled={isGenerating}
-            onClick={() => setIsManualPasteOpen((prev) => !prev)}
-          >
-            {isManualPasteOpen ? <LuChevronUp /> : <LuChevronDown />}
-          </IconButton>
-        </HStack>
-
-        {isManualPasteOpen ? (
-          <Box
-            ref={popoverRef}
-            position={"absolute"}
-            top={"calc(100% + 6px)"}
-            left={0}
-            zIndex={20}
+        <Popover.Positioner zIndex={20}>
+          <Popover.Content
             p={0}
             borderWidth={"1px"}
             borderColor={"app.epub.border.default"}
@@ -231,9 +198,9 @@ export function EpubToolbar({
             >
               Add pasted content
             </Button>
-          </Box>
-        ) : null}
-      </Box>
+          </Popover.Content>
+        </Popover.Positioner>
+      </Popover.Root>
 
       <Button
         {...actionButtonProps}

--- a/src/features/epub-maker/components/PageDraftCard.tsx
+++ b/src/features/epub-maker/components/PageDraftCard.tsx
@@ -12,6 +12,7 @@ import {
   Text,
   VStack,
 } from "@chakra-ui/react";
+import { Field } from "@components/ui/field";
 import { Menu } from "@components/ui/menu";
 import { NumberInput } from "@components/ui/number-input";
 import { Switch } from "@components/ui/switch";
@@ -448,6 +449,11 @@ export function PageDraftCard({
     bg: "app.epub.bg.card",
     color: "app.epub.fg.default",
     borderColor: "app.epub.border.default",
+  } as const;
+  const dialogFieldLabelProps = {
+    fontSize: "sm",
+    color: "app.epub.fg.muted",
+    mb: 1,
   } as const;
   const dialogOutlineButtonProps = {
     size: "md",
@@ -923,14 +929,10 @@ export function PageDraftCard({
                               md: "minmax(0, 1fr)",
                             }}
                           >
-                            <Box>
-                              <Text
-                                fontSize={"sm"}
-                                color={"app.epub.fg.muted"}
-                                mb={1}
-                              >
-                                Background
-                              </Text>
+                            <Field
+                              label={"Background"}
+                              labelProps={dialogFieldLabelProps}
+                            >
                               <Menu.Root
                                 positioning={{
                                   placement: "bottom-start",
@@ -1197,16 +1199,12 @@ export function PageDraftCard({
                                   </Menu.Content>
                                 </Menu.Positioner>
                               </Menu.Root>
-                            </Box>
+                            </Field>
 
-                            <Box>
-                              <Text
-                                fontSize={"sm"}
-                                color={"app.epub.fg.muted"}
-                                mb={1}
-                              >
-                                Size
-                              </Text>
+                            <Field
+                              label={"Size"}
+                              labelProps={dialogFieldLabelProps}
+                            >
                               <Menu.Root
                                 positioning={{
                                   placement: "bottom-start",
@@ -1463,7 +1461,7 @@ export function PageDraftCard({
                                   </Menu.Content>
                                 </Menu.Positioner>
                               </Menu.Root>
-                            </Box>
+                            </Field>
 
                           </Box>
 
@@ -1510,14 +1508,10 @@ export function PageDraftCard({
                                 sm: "repeat(2, minmax(0, 1fr))",
                               }}
                             >
-                              <Box>
-                                <Text
-                                  fontSize={"sm"}
-                                  color={"app.epub.fg.muted"}
-                                  mb={1}
-                                >
-                                  Text size (%)
-                                </Text>
+                              <Field
+                                label={"Text size (%)"}
+                                labelProps={dialogFieldLabelProps}
+                              >
                                 <NumberInput.Root
                                   {...dialogFieldProps}
                                   size={"md"}
@@ -1543,16 +1537,12 @@ export function PageDraftCard({
                                     color={"app.epub.fg.default"}
                                   />
                                 </NumberInput.Root>
-                              </Box>
+                              </Field>
 
-                              <Box>
-                                <Text
-                                  fontSize={"sm"}
-                                  color={"app.epub.fg.muted"}
-                                  mb={1}
-                                >
-                                  Text color
-                                </Text>
+                              <Field
+                                label={"Text color"}
+                                labelProps={dialogFieldLabelProps}
+                              >
                                 <NativeSelect.Root
                                   {...dialogFieldProps}
                                   size={"md"}
@@ -1581,17 +1571,13 @@ export function PageDraftCard({
                                     <option value={"adaptive"}>Adaptive</option>
                                   </NativeSelect.Field>
                                 </NativeSelect.Root>
-                              </Box>
+                              </Field>
                             </Box>
 
-                            <Box>
-                              <Text
-                                fontSize={"sm"}
-                                color={"app.epub.fg.muted"}
-                                mb={1}
-                              >
-                                Text position
-                              </Text>
+                            <Field
+                              label={"Text position"}
+                              labelProps={dialogFieldLabelProps}
+                            >
                               <Menu.Root
                                 positioning={{
                                   placement: "bottom-start",
@@ -1764,7 +1750,7 @@ export function PageDraftCard({
                                   </Menu.Content>
                                 </Menu.Positioner>
                               </Menu.Root>
-                            </Box>
+                            </Field>
                           </VStack>
                         </Box>
                       </VStack>

--- a/src/features/tools/components/ToolCard.tsx
+++ b/src/features/tools/components/ToolCard.tsx
@@ -1,4 +1,4 @@
-import { HStack, Icon, Text, VStack } from "@chakra-ui/react";
+import { HStack, Icon, LinkBox, LinkOverlay, Text, VStack } from "@chakra-ui/react";
 import { CategoryBadge, FeaturedIndicator } from "@components/core/Badges";
 import { InnerBgCardWithHeader } from "@components/core/Cards";
 import NextLink from "next/link";
@@ -15,7 +15,7 @@ export function ToolCard({ tool }: { tool: ToolDefinition }) {
 
   return (
     <InnerBgCardWithHeader py={[2, 4]}>
-      <NextLink href={tool.path} style={{ display: "block" }}>
+      <LinkBox>
         <VStack align={"stretch"} gap={3}>
           <HStack justify={"space-between"} align={"start"}>
             <VStack align={"start"} gap={1}>
@@ -45,7 +45,8 @@ export function ToolCard({ tool }: { tool: ToolDefinition }) {
             </HStack>
           </HStack>
         </VStack>
-      </NextLink>
+        <LinkOverlay as={NextLink} href={tool.path} aria-label={tool.name} />
+      </LinkBox>
     </InnerBgCardWithHeader>
   );
 }

--- a/src/features/tools/components/ToolsDirectoryPage.tsx
+++ b/src/features/tools/components/ToolsDirectoryPage.tsx
@@ -1,6 +1,16 @@
 "use client";
 
-import { Bleed, Box, EmptyState, HStack, Icon, Text, VStack } from "@chakra-ui/react";
+import {
+  Bleed,
+  Box,
+  EmptyState,
+  HStack,
+  Icon,
+  LinkBox,
+  LinkOverlay,
+  Text,
+  VStack,
+} from "@chakra-ui/react";
 import { CategoryBadge, FeaturedIndicator } from "@components/core/Badges";
 import { Heading1, SubtitleText } from "@components/core/Texts";
 import { TileList } from "@components/core/Tiles";
@@ -30,7 +40,7 @@ function ToolListTile({ tool }: { tool: ToolDefinition }) {
   const ToolIcon = getToolIcon(tool.icon);
 
   return (
-    <NextLink href={tool.path} style={{ display: "block" }}>
+    <LinkBox>
       <Box px={[1, 2]} py={[2, 3]}>
         <VStack align={"stretch"} gap={2}>
           <HStack justify={"space-between"} align={"start"}>
@@ -64,7 +74,8 @@ function ToolListTile({ tool }: { tool: ToolDefinition }) {
           </HStack>
         </VStack>
       </Box>
-    </NextLink>
+      <LinkOverlay as={NextLink} href={tool.path} aria-label={tool.name} />
+    </LinkBox>
   );
 }
 

--- a/src/features/tools/components/ToolsDirectoryPage.tsx
+++ b/src/features/tools/components/ToolsDirectoryPage.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Box, EmptyState, HStack, Icon, Text, VStack } from "@chakra-ui/react";
+import { Bleed, Box, EmptyState, HStack, Icon, Text, VStack } from "@chakra-ui/react";
 import { CategoryBadge, FeaturedIndicator } from "@components/core/Badges";
 import { Heading1, SubtitleText } from "@components/core/Texts";
 import { TileList } from "@components/core/Tiles";
@@ -127,24 +127,28 @@ export function ToolsDirectoryPage() {
       />
 
       {visibleTools.length === 0 ? (
-        <HighlightedSection>
-          <EmptyState.Root>
-            <EmptyState.Content>
-              <EmptyState.Indicator>
-                <Icon as={FiTool} boxSize={10} color={"app.fg.icon"} />
-              </EmptyState.Indicator>
-              <EmptyState.Title>{content.emptyStateTitle}</EmptyState.Title>
-            </EmptyState.Content>
-          </EmptyState.Root>
-        </HighlightedSection>
+        <Bleed inline={{ base: 1, md: 2 }}>
+          <HighlightedSection>
+            <EmptyState.Root>
+              <EmptyState.Content>
+                <EmptyState.Indicator>
+                  <Icon as={FiTool} boxSize={10} color={"app.fg.icon"} />
+                </EmptyState.Indicator>
+                <EmptyState.Title>{content.emptyStateTitle}</EmptyState.Title>
+              </EmptyState.Content>
+            </EmptyState.Root>
+          </HighlightedSection>
+        </Bleed>
       ) : (
-        <HighlightedSection>
-          <TileList>
-            {visibleTools.map((tool) => (
-              <ToolListTile key={tool.id} tool={tool} />
-            ))}
-          </TileList>
-        </HighlightedSection>
+        <Bleed inline={{ base: 1, md: 2 }}>
+          <HighlightedSection>
+            <TileList>
+              {visibleTools.map((tool) => (
+                <ToolListTile key={tool.id} tool={tool} />
+              ))}
+            </TileList>
+          </HighlightedSection>
+        </Bleed>
       )}
     </VStack>
   );


### PR DESCRIPTION
## Summary
- replace custom dividers with Chakra Separator and semantic defaults
- use Chakra Field, Bleed, Popover, LinkBox/LinkOverlay, and Collapsible in targeted UI surfaces
- align feature flags section bleed with the other list pages

## Verification
- yarn test:functional: 122 passed