### PR TITLE
Fix blog typography

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
   "dependencies": {
     "@chakra-ui/react": "^3.2.4",
     "@emotion/react": "^11.14.0",
-    "computer-modern": "^0.1.3",
     "gray-matter": "^4.0.3",
     "jszip": "^3.10.1",
     "next": "16.1.6",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,9 +1,8 @@
 import { Providers } from "./providers";
 import { Metadata } from "next";
 import { SITE_OWNER_NAME } from "./metadata";
-import { Caveat, Lexend, Noto_Sans } from "next/font/google";
+import { Caveat, Lexend, Noto_Sans, Source_Serif_4 } from "next/font/google";
 import "katex/dist/katex.min.css";
-import "computer-modern/index.css";
 
 const lexend = Lexend({
   subsets: ["latin"],
@@ -17,6 +16,13 @@ const notoSans = Noto_Sans({
   weight: ["400", "500", "600", "700"],
   display: "swap",
   variable: "--font-noto-sans",
+});
+
+const sourceSerif = Source_Serif_4({
+  subsets: ["latin"],
+  weight: ["400", "500", "600", "700"],
+  display: "swap",
+  variable: "--font-source-serif",
 });
 
 const handwritten = Caveat({
@@ -39,7 +45,7 @@ export default function RootLayout({
     <html lang={"en"} suppressHydrationWarning>
       <head />
       <body
-        className={`${notoSans.className} ${lexend.variable} ${notoSans.variable} ${handwritten.variable}`}
+        className={`${notoSans.className} ${lexend.variable} ${notoSans.variable} ${sourceSerif.variable} ${handwritten.variable}`}
       >
         <a className="skip-link" href="#main-content">
           Skip to main content

--- a/src/components/article/proseStyles.ts
+++ b/src/components/article/proseStyles.ts
@@ -5,13 +5,13 @@ import type { CSSObject } from "@emotion/react";
 
 export function useProseStyles(): CSSObject {
   const proseBodyFontFamily =
-    "'CMU Sans Serif', 'Computer Modern Sans', sans-serif";
+    "'Source Serif 4', Georgia, 'Times New Roman', serif";
   const proseHeadingFontFamily = "'Lexend', sans-serif";
   const proseCodeFontFamily =
-    "'CMU Typewriter Text', 'CMU Typewriter', 'Computer Modern Typewriter', mono";
+    "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace";
 
   const headingColor = useColorModeValue("gray.800", "whiteAlpha.900");
-  const textColor = useColorModeValue("gray.700", "gray.200");
+  const textColor = useColorModeValue("gray.900", "gray.100");
   const subtleTextColor = useColorModeValue("gray.600", "gray.400");
   const linkColor = useColorModeValue("#007a8a", "teal.300");
   const borderColor = useColorModeValue("gray.200", "gray.700");
@@ -33,9 +33,9 @@ export function useProseStyles(): CSSObject {
     marginInline: "auto",
     wordBreak: "normal",
     overflowWrap: "break-word",
-    hyphens: "auto",
-    WebkitHyphens: "auto",
-    msHyphens: "auto",
+    hyphens: "none",
+    WebkitHyphens: "none",
+    msHyphens: "none",
     "& > *": {
       marginTop: 0,
       marginBottom: 7,
@@ -69,7 +69,9 @@ export function useProseStyles(): CSSObject {
     "& p": {
       marginBottom: 7,
       textAlign: "justify",
-      hyphens: "auto",
+      hyphens: "none",
+      WebkitHyphens: "none",
+      msHyphens: "none",
     },
     "& p:last-of-type": {
       marginBottom: 0,
@@ -134,7 +136,9 @@ export function useProseStyles(): CSSObject {
     },
     "& li": {
       marginBottom: 2,
-      hyphens: "auto",
+      hyphens: "none",
+      WebkitHyphens: "none",
+      msHyphens: "none",
     },
     "& li::marker": {
       color: useColorModeValue("gray.400", "gray.500"),

--- a/src/components/core/Texts.tsx
+++ b/src/components/core/Texts.tsx
@@ -118,14 +118,14 @@ export function ParagraphText({
   return (
     <Text
       color={"app.fg.muted"}
-      fontFamily={"'CMU Sans Serif', 'Noto Sans', sans-serif"}
+      fontFamily={"body"}
       fontSize={fontSize}
       fontWeight={"normal"}
       lineHeight={"1.42"}
       letterSpacing={"0.01em"}
       textAlign={justifyText ? "justify" : "left"}
-      hyphens={justifyText ? "auto" : undefined}
-      css={justifyText ? { WebkitHyphens: "auto", textWrap: "pretty" } : undefined}
+      hyphens={justifyText ? "none" : undefined}
+      css={justifyText ? { WebkitHyphens: "none", textWrap: "pretty" } : undefined}
       {...textProps}
     >
       {children}

--- a/src/components/page/cv/CvAccomplishmentsSection.tsx
+++ b/src/components/page/cv/CvAccomplishmentsSection.tsx
@@ -19,7 +19,7 @@ import { FiLink, FiEye } from "react-icons/fi";
 import CvSection from "./CvSection";
 import { AppAccentPalette, AppPalette } from "theme/colors";
 import {
-  CV_CMU_FONT_FAMILY,
+  CV_BODY_FONT_FAMILY,
   CV_META_TEXT_SIZE,
   CV_SECONDARY_TEXT_COLOR,
 } from "./cvStyleTokens";
@@ -93,7 +93,7 @@ function AccomplishmentCard({
                   aria-label={`Open ${item.title} credential (opens in a new tab)`}
                   fontSize={CV_META_TEXT_SIZE}
                   color={CV_SECONDARY_TEXT_COLOR}
-                  fontFamily={CV_CMU_FONT_FAMILY}
+                  fontFamily={CV_BODY_FONT_FAMILY}
                   _hover={{ color: "app.fg.default" }}
                 >
                   <Icon as={FiLink} />
@@ -105,7 +105,7 @@ function AccomplishmentCard({
             <Text
               fontSize={CV_META_TEXT_SIZE}
               color={CV_SECONDARY_TEXT_COLOR}
-              fontFamily={CV_CMU_FONT_FAMILY}
+              fontFamily={CV_BODY_FONT_FAMILY}
             >
               {metaText}
             </Text>

--- a/src/components/page/cv/CvContactSection.tsx
+++ b/src/components/page/cv/CvContactSection.tsx
@@ -11,7 +11,7 @@ import {
 } from "react-icons/fi";
 import type { AppAccentPalette, AppPalette } from "theme/colors/types";
 import CvSection from "./CvSection";
-import { CV_CMU_FONT_FAMILY, CV_META_TEXT_SIZE } from "./cvStyleTokens";
+import { CV_BODY_FONT_FAMILY, CV_META_TEXT_SIZE } from "./cvStyleTokens";
 
 function iconFromKey(iconKey?: CvContactChannel["iconKey"]) {
   switch (iconKey) {
@@ -54,7 +54,7 @@ function ContactItem({ item }: { item: CvContactChannel }) {
           fontSize={CV_META_TEXT_SIZE}
           color={textColor}
           fontWeight="medium"
-          fontFamily={CV_CMU_FONT_FAMILY}
+          fontFamily={CV_BODY_FONT_FAMILY}
           display={{ base: "none", md: "block" }}
         >
           {item.label}
@@ -66,7 +66,7 @@ function ContactItem({ item }: { item: CvContactChannel }) {
           target="_blank"
           rel="noopener noreferrer"
           fontSize={CV_META_TEXT_SIZE}
-          fontFamily={CV_CMU_FONT_FAMILY}
+          fontFamily={CV_BODY_FONT_FAMILY}
         >
           {item.value}
         </Link>
@@ -74,7 +74,7 @@ function ContactItem({ item }: { item: CvContactChannel }) {
         <Text
           fontSize={CV_META_TEXT_SIZE}
           color={textColor}
-          fontFamily={CV_CMU_FONT_FAMILY}
+          fontFamily={CV_BODY_FONT_FAMILY}
         >
           {item.value}
         </Text>

--- a/src/components/page/cv/CvCoursesSection.tsx
+++ b/src/components/page/cv/CvCoursesSection.tsx
@@ -6,7 +6,7 @@ import type { AppAccentPalette, AppPalette } from "theme/colors/types";
 import CvSection from "./CvSection";
 import { formatCvDate } from "./cvRenderUtils";
 import {
-  CV_CMU_FONT_FAMILY,
+  CV_BODY_FONT_FAMILY,
   CV_META_TEXT_SIZE,
   CV_SECONDARY_TEXT_COLOR,
 } from "./cvStyleTokens";
@@ -78,7 +78,7 @@ export default function CvCoursesSection({
                         color={badgeColor}
                         whiteSpace="nowrap"
                         fontWeight="medium"
-                        fontFamily={CV_CMU_FONT_FAMILY}
+                        fontFamily={CV_BODY_FONT_FAMILY}
                       >
                         {item.courseCode}
                       </Text>
@@ -90,7 +90,7 @@ export default function CvCoursesSection({
                       fontSize={CV_META_TEXT_SIZE}
                       fontWeight="medium"
                       color="app.fg.muted"
-                      fontFamily={CV_CMU_FONT_FAMILY}
+                      fontFamily={CV_BODY_FONT_FAMILY}
                     >
                       {item.institution}
                     </Text>
@@ -103,7 +103,7 @@ export default function CvCoursesSection({
                       <Text
                         fontSize={CV_META_TEXT_SIZE}
                         color={mutedColor}
-                        fontFamily={CV_CMU_FONT_FAMILY}
+                        fontFamily={CV_BODY_FONT_FAMILY}
                       >
                         {timeframe}
                       </Text>
@@ -115,7 +115,7 @@ export default function CvCoursesSection({
                       <Text
                         fontSize={CV_META_TEXT_SIZE}
                         fontWeight="bold"
-                        fontFamily={CV_CMU_FONT_FAMILY}
+                        fontFamily={CV_BODY_FONT_FAMILY}
                         color={
                           accentColorPalette
                             ? `${accentColorPalette}.fg`

--- a/src/components/page/cv/CvHero.tsx
+++ b/src/components/page/cv/CvHero.tsx
@@ -23,7 +23,7 @@ import {
 import { FaXTwitter } from "react-icons/fa6";
 import { Tooltip } from "@components/ui/tooltip";
 import PersonalData from "../../../data/Personal";
-import { CV_CMU_FONT_FAMILY } from "./cvStyleTokens";
+import { CV_BODY_FONT_FAMILY } from "./cvStyleTokens";
 
 export default function CvHero({ profile }: { profile: CvProfile }) {
   const secondaryColor = "app.fg.muted";
@@ -63,7 +63,7 @@ export default function CvHero({ profile }: { profile: CvProfile }) {
         <Text
           fontSize={"19px"}
           color={"app.fg.subtle"}
-          fontFamily={CV_CMU_FONT_FAMILY}
+          fontFamily={CV_BODY_FONT_FAMILY}
         >
           {profile.headline}
         </Text>
@@ -76,7 +76,7 @@ export default function CvHero({ profile }: { profile: CvProfile }) {
                 <Icon as={FiMapPin} />
                 <Text
                   fontSize={contactTextSize}
-                  fontFamily={CV_CMU_FONT_FAMILY}
+                  fontFamily={CV_BODY_FONT_FAMILY}
                   fontWeight="medium"
                 >
                   {profile.location}
@@ -93,7 +93,7 @@ export default function CvHero({ profile }: { profile: CvProfile }) {
                 <Icon as={FiMail} />
                 <Link
                   fontSize={contactTextSize}
-                  fontFamily={CV_CMU_FONT_FAMILY}
+                  fontFamily={CV_BODY_FONT_FAMILY}
                   fontWeight="medium"
                   href={`mailto:${profile.email}`}
                 >
@@ -109,7 +109,7 @@ export default function CvHero({ profile }: { profile: CvProfile }) {
                       as="button"
                       fontSize="17px"
                       color={secondaryColor}
-                      fontFamily={CV_CMU_FONT_FAMILY}
+                      fontFamily={CV_BODY_FONT_FAMILY}
                       fontWeight="medium"
                     >
                       <HStack gap={1}>
@@ -144,7 +144,7 @@ export default function CvHero({ profile }: { profile: CvProfile }) {
                       rel="noopener noreferrer"
                       fontSize={contactTextSize}
                       color={secondaryColor}
-                      fontFamily={CV_CMU_FONT_FAMILY}
+                      fontFamily={CV_BODY_FONT_FAMILY}
                       fontWeight="medium"
                     >
                       {link.label}
@@ -154,7 +154,7 @@ export default function CvHero({ profile }: { profile: CvProfile }) {
                     <Text
                       fontSize={contactTextSize}
                       color={secondaryColor}
-                      fontFamily={CV_CMU_FONT_FAMILY}
+                      fontFamily={CV_BODY_FONT_FAMILY}
                       aria-hidden="true"
                     >
                       •

--- a/src/components/page/cv/CvJumpNav.tsx
+++ b/src/components/page/cv/CvJumpNav.tsx
@@ -2,7 +2,7 @@ import { Link, Wrap, WrapItem, Text } from "@chakra-ui/react";
 import type { CvData } from "data/cv";
 import { getRenderableCvSections } from "./cvRenderUtils";
 import { getCvSectionPaletteUnsafe } from "./cvPalettes";
-import { CV_CMU_FONT_FAMILY, CV_META_TEXT_SIZE } from "./cvStyleTokens";
+import { CV_BODY_FONT_FAMILY, CV_META_TEXT_SIZE } from "./cvStyleTokens";
 
 export function renderSectionAnchorLinks(sections: CvData["sections"]) {
   return getRenderableCvSections(sections).map((section) => ({
@@ -26,7 +26,7 @@ export default function CvJumpNav({ sections }: { sections: CvData["sections"] }
             <WrapItem>
               <Link
                 href={`#${link.id}`}
-                fontFamily={CV_CMU_FONT_FAMILY}
+                fontFamily={CV_BODY_FONT_FAMILY}
                 fontSize={CV_META_TEXT_SIZE}
                 color={`${link.accentColorPalette}.fg`}
                 _hover={{
@@ -41,7 +41,7 @@ export default function CvJumpNav({ sections }: { sections: CvData["sections"] }
                 <Text
                   fontSize={CV_META_TEXT_SIZE}
                   color={separatorColor}
-                  fontFamily={CV_CMU_FONT_FAMILY}
+                  fontFamily={CV_BODY_FONT_FAMILY}
                   aria-hidden="true"
                 >
                   •

--- a/src/components/page/cv/CvLanguagesSection.tsx
+++ b/src/components/page/cv/CvLanguagesSection.tsx
@@ -4,7 +4,7 @@ import type { CvLanguageItem, CvSectionBase } from "data/cv";
 import type { ElementType } from "react";
 import CvSection from "./CvSection";
 import type { AppAccentPalette, AppPalette } from "theme/colors/types";
-import { CV_CMU_FONT_FAMILY, CV_META_TEXT_SIZE } from "./cvStyleTokens";
+import { CV_BODY_FONT_FAMILY, CV_META_TEXT_SIZE } from "./cvStyleTokens";
 
 function fluencyLabel(value?: CvLanguageItem["proficiency"]) {
   if (!value) return "Not specified";
@@ -67,7 +67,7 @@ export default function CvLanguagesSection({
                   <Text
                     fontSize={CV_META_TEXT_SIZE}
                     color={mutedColor}
-                    fontFamily={CV_CMU_FONT_FAMILY}
+                    fontFamily={CV_BODY_FONT_FAMILY}
                   >
                     {item.nativeName}
                   </Text>
@@ -81,7 +81,7 @@ export default function CvLanguagesSection({
                 bg={fluencyBg}
                 color={fluencyColor}
                 whiteSpace="nowrap"
-                fontFamily={CV_CMU_FONT_FAMILY}
+                fontFamily={CV_BODY_FONT_FAMILY}
               >
                 {fluencyLabel(item.proficiency)}
               </Text>

--- a/src/components/page/cv/CvProjectsSection.tsx
+++ b/src/components/page/cv/CvProjectsSection.tsx
@@ -19,8 +19,8 @@ import type { AppAccentPalette, AppPalette } from "theme/colors/types";
 import {
   CV_BULLET_ITEM_GAP,
   CV_BULLET_TEXT_COLOR,
-  CV_CMU_BULLET_FONT_FAMILY,
-  CV_CMU_FONT_FAMILY,
+  CV_BULLET_FONT_FAMILY,
+  CV_BODY_FONT_FAMILY,
   CV_BULLET_LINE_HEIGHT,
   CV_BULLET_TEXT_SIZE,
   CV_META_TEXT_SIZE,
@@ -59,7 +59,7 @@ function ProjectCard({
             <Text
               fontSize={CV_META_TEXT_SIZE}
               color={CV_SECONDARY_TEXT_COLOR}
-              fontFamily={CV_CMU_FONT_FAMILY}
+              fontFamily={CV_BODY_FONT_FAMILY}
             >
               {timeframe}
             </Text>
@@ -70,7 +70,7 @@ function ProjectCard({
             href={item.url}
             target="_blank"
             rel="noopener noreferrer"
-            fontFamily={CV_CMU_FONT_FAMILY}
+            fontFamily={CV_BODY_FONT_FAMILY}
             fontSize={CV_META_TEXT_SIZE}
             color={CV_SECONDARY_TEXT_COLOR}
           >
@@ -95,7 +95,7 @@ function ProjectCard({
               <Text
                 fontSize={CV_BULLET_TEXT_SIZE}
                 color={CV_BULLET_TEXT_COLOR}
-                fontFamily={CV_CMU_BULLET_FONT_FAMILY}
+                fontFamily={CV_BULLET_FONT_FAMILY}
                 lineHeight={CV_BULLET_LINE_HEIGHT}
                 textAlign="justify"
                 hyphens="auto"

--- a/src/components/page/cv/CvSection.tsx
+++ b/src/components/page/cv/CvSection.tsx
@@ -4,7 +4,7 @@ import { HEADER_OFFSET_HEIGHT } from "@components/page/common/Header";
 import type { ReactNode } from "react";
 import type { ElementType } from "react";
 import type { AppAccentPalette, AppPalette } from "theme/colors/types";
-import { CV_CMU_FONT_FAMILY, CV_META_TEXT_SIZE } from "./cvStyleTokens";
+import { CV_BODY_FONT_FAMILY, CV_META_TEXT_SIZE } from "./cvStyleTokens";
 
 export default function CvSection({
   id,
@@ -38,7 +38,7 @@ export default function CvSection({
               <Text
                 fontSize={CV_META_TEXT_SIZE}
                 color={"app.fg.subtle"}
-                fontFamily={CV_CMU_FONT_FAMILY}
+                fontFamily={CV_BODY_FONT_FAMILY}
               >
                 {description}
               </Text>

--- a/src/components/page/cv/CvSkillsSection.tsx
+++ b/src/components/page/cv/CvSkillsSection.tsx
@@ -4,7 +4,7 @@ import type { ElementType } from "react";
 import { Tooltip } from "@components/ui/tooltip";
 import CvSection from "./CvSection";
 import type { AppAccentPalette, AppPalette } from "theme/colors/types";
-import { CV_CMU_FONT_FAMILY, CV_META_TEXT_SIZE } from "./cvStyleTokens";
+import { CV_BODY_FONT_FAMILY, CV_META_TEXT_SIZE } from "./cvStyleTokens";
 
 const LEVEL_SCALE: Record<string, number> = {
   beginner: 1,
@@ -78,7 +78,7 @@ export default function CvSkillsSection({
               fontWeight="bold"
               color="app.fg.muted"
               letterSpacing="wider"
-              fontFamily={CV_CMU_FONT_FAMILY}
+              fontFamily={CV_BODY_FONT_FAMILY}
             >
               {group.group}
             </Text>
@@ -110,7 +110,7 @@ export default function CvSkillsSection({
                         fontSize={CV_META_TEXT_SIZE}
                         fontWeight="normal"
                         color="app.fg.default"
-                        fontFamily={CV_CMU_FONT_FAMILY}
+                        fontFamily={CV_BODY_FONT_FAMILY}
                       >
                         {item.name}
                       </Text>

--- a/src/components/page/cv/CvTimelineSection.tsx
+++ b/src/components/page/cv/CvTimelineSection.tsx
@@ -20,8 +20,8 @@ import type { AppAccentPalette, AppPalette } from "theme/colors/types";
 import {
   CV_BULLET_ITEM_GAP,
   CV_BULLET_TEXT_COLOR,
-  CV_CMU_BULLET_FONT_FAMILY,
-  CV_CMU_FONT_FAMILY,
+  CV_BULLET_FONT_FAMILY,
+  CV_BODY_FONT_FAMILY,
   CV_BULLET_LINE_HEIGHT,
   CV_BULLET_TEXT_SIZE,
   CV_META_TEXT_SIZE,
@@ -71,7 +71,7 @@ function TimelineItem({
                 color={emphasizeOrganization ? "app.fg.muted" : CV_SECONDARY_TEXT_COLOR}
                 fontSize={CV_META_TEXT_SIZE}
                 fontWeight={emphasizeOrganization ? "medium" : "normal"}
-                fontFamily={CV_CMU_FONT_FAMILY}
+                fontFamily={CV_BODY_FONT_FAMILY}
               >
                 · {item.organization}
               </Text>
@@ -82,7 +82,7 @@ function TimelineItem({
                 color={CV_SECONDARY_TEXT_COLOR}
                 fontSize={CV_META_TEXT_SIZE}
                 wrap="wrap"
-                fontFamily={CV_CMU_FONT_FAMILY}
+                fontFamily={CV_BODY_FONT_FAMILY}
               >
                 {timeframe ? <Text>{timeframe}</Text> : null}
                 {item.location ? <Text>{`· ${item.location}`}</Text> : null}
@@ -94,7 +94,7 @@ function TimelineItem({
               href={item.url}
               target="_blank"
               rel="noopener noreferrer"
-              fontFamily={CV_CMU_FONT_FAMILY}
+              fontFamily={CV_BODY_FONT_FAMILY}
               fontSize={CV_META_TEXT_SIZE}
               color={CV_SECONDARY_TEXT_COLOR}
             >
@@ -119,7 +119,7 @@ function TimelineItem({
                 <Text
                   fontSize={CV_BULLET_TEXT_SIZE}
                   color={CV_BULLET_TEXT_COLOR}
-                  fontFamily={CV_CMU_BULLET_FONT_FAMILY}
+                  fontFamily={CV_BULLET_FONT_FAMILY}
                   lineHeight={CV_BULLET_LINE_HEIGHT}
                   textAlign="justify"
                   hyphens="auto"

--- a/src/components/page/cv/cvStyleTokens.ts
+++ b/src/components/page/cv/cvStyleTokens.ts
@@ -1,9 +1,8 @@
 export const CV_SECONDARY_TEXT_COLOR = "app.fg.subtle" as const;
 export const CV_BULLET_TEXT_COLOR = "app.fg.muted" as const;
-export const CV_CMU_FONT_FAMILY =
-  "'CMU Sans Serif', 'Noto Sans', sans-serif" as const;
+export const CV_BODY_FONT_FAMILY = "body" as const;
 export const CV_META_TEXT_SIZE = "17px" as const;
 export const CV_BULLET_TEXT_SIZE = "18px" as const;
 export const CV_BULLET_LINE_HEIGHT = "1.3" as const;
 export const CV_BULLET_ITEM_GAP = "6px" as const;
-export const CV_CMU_BULLET_FONT_FAMILY = CV_CMU_FONT_FAMILY;
+export const CV_BULLET_FONT_FAMILY = CV_BODY_FONT_FAMILY;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2141,11 +2141,6 @@ commander@^8.3.0:
   resolved "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz#4837ea1b2da67b9c616a67afbb0fafee567bca66"
   integrity sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==
 
-computer-modern@^0.1.3:
-  version "0.1.3"
-  resolved "https://registry.npmjs.org/computer-modern/-/computer-modern-0.1.3.tgz#5a2bfdaf150ae57ac7d7df03cdc6c316a53e676b"
-  integrity sha512-tJz506hr2RPksqdYs0VJz98gE1TcpYs/L/kk5MTkEbtgCLRJ1xwcL8rXkzsSnyBqNCyrI+1paZE8Jat6d7wN2Q==
-
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"


### PR DESCRIPTION
Closes #95

## Summary
- remove the Computer Modern dependency and stylesheet import
- switch article prose to Source Serif 4 via next/font
- disable forced hyphenation for prose/body text
- rename CV font tokens to agnostic names while keeping them on the body font
- increase article body text contrast in both light and dark modes

## Validation
- yarn typecheck
- yarn lint