### PR TITLE
Resize EPUB cover settings preview

### DIFF
--- a/src/features/epub-maker/components/PageDraftCard.tsx
+++ b/src/features/epub-maker/components/PageDraftCard.tsx
@@ -1755,8 +1755,21 @@ export function PageDraftCard({
                         </Box>
                       </VStack>
 
-                      <Box>
-                        <AspectRatio ratio={dialogPreviewRatio}>
+                      <Box
+                        display={"flex"}
+                        justifyContent={"center"}
+                        w={"full"}
+                      >
+                        <AspectRatio
+                          ratio={dialogPreviewRatio}
+                          w={"full"}
+                          maxW={{
+                            base: "64",
+                            md: "72",
+                            lg: "80",
+                            xl: "96",
+                          }}
+                        >
                           <Box
                             position={"relative"}
                             rounded={"lg"}


### PR DESCRIPTION
## Summary
- Cap the EPUB cover settings preview with responsive Chakra size tokens
- Center the preview inside the dialog column while preserving the selected cover aspect ratio

Closes #93

## Validation
- yarn typecheck
- yarn lint
- yarn test:functional tests/functional/tools/epub-maker/cover.spec.ts